### PR TITLE
WMDP-26 Set Up PR Template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-## [Ticket](https://wicmtdp.atlassian.net/browse/{TICKET_ID})
+## Ticket
+
+https://wicmtdp.atlassian.net/browse/{TICKET_ID}
+
 ## Changes
 > What was added, updated, or removed in this PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## [Ticket](https://wicmtdp.atlassian.net/browse/{TICKET_ID})
+## Changes
+> What was added, updated, or removed in this PR.
+
+## Context for reviewers
+> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.
+
+## Testing
+> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.


### PR DESCRIPTION
## [Ticket](https://wicmtdp.atlassian.net/browse/WMDP-26)
## Changes
* added a `.github` folder which should store all github related processes (e.g. github actions, and templates)
* added PR template
## Context for reviewers
> We want to establish a consistent pull request template that we’ll use.
GitHub docs on the subject [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
## Testing
New PRs should look like this after this change is added: 
![image](https://user-images.githubusercontent.com/37313082/168332438-22c8a125-291f-4075-92da-6bd271abb671.png)