### PR TITLE
Create a separate tsconfig file to specify jsx mode for ts-jest vs next.js

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -19,5 +19,10 @@ module.exports = {
   testPathIgnorePatterns: [
     "<rootDir>/node_modules/",
   ],
-  testRegex: "(/test/.*(test|spec))\\.[jt]sx?$"
+  testRegex: "(/test/.*(test|spec))\\.[jt]sx?$",
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.ts-jest.json'
+    }
+  }
 };

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -2,10 +2,16 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@pages/*": ["pages/*"]
+      "@pages/*": [
+        "pages/*"
+      ]
     },
     "target": "es6",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "checkJs": true,
     "skipLibCheck": true,
@@ -17,9 +23,16 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "__mocks__/styleMock.js"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "__mocks__/styleMock.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/app/tsconfig.ts-jest.json
+++ b/app/tsconfig.ts-jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}


### PR DESCRIPTION
## Ticket

- https://wicmtdp.atlassian.net/browse/WMDP-99

## Changes
> What was added, updated, or removed in this PR.

- Modifies `tsconfig.json` to use jsx mode `preserve` 
- Introduces `tsconfig.ts-jest.json` to allow ts-jest to use jsx mode `react-jsx`

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Next.js requires the typescript jsx mode to be `preserve` and will make a mandatory correction when you run `yarn dev` or `yarn build` with the following message:

> The following mandatory changes were made to your tsconfig.json:
>
>	- jsx was set to preserve (next.js implements its own optimized jsx transform)

However, ts-jest needs it to be a flavor of `react`. 

For more info, see:

- https://www.typescriptlang.org/docs/handbook/jsx.html
- https://kulshekhar.github.io/ts-jest/docs/getting-started/options/tsconfig
- https://github.com/kulshekhar/ts-jest/issues/63#issuecomment-848190677
- https://github.com/vercel/next.js/discussions/19155#discussioncomment-729466

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Run `yarn install`
2. Run `yarn dev`. The dev server should start up with no complaints (the message above should not be displayed).
3. Run `yarn test`. The tests should pass and should not return the failure "Jest encountered an unexpected token"
