### PR TITLE
setup CI for NextJS template app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: NextJS CI
+
+on:
+  push:
+    branches-ignore: [main]
+
+jobs:
+  test:
+    name: pass/fail checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./app
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 16
+    - run: npm install --location=global yarn
+    - run: yarn install --frozen-lockfile
+    - run: yarn build
+    - run: yarn lint
+    - run: yarn format-check
+    - run: yarn test
+    

--- a/app/.prettierignore
+++ b/app/.prettierignore
@@ -1,0 +1,20 @@
+# Ignoring generated files
+.next/
+node_modules/
+
+# Throwing the decision on formatting these over the fence.
+__mocks__/styleMock.js
+.eslintrc.json
+.prettierrc.json
+jest.config.js
+next-env.d.ts
+next.config.js
+package.json
+pages/_app.tsx
+pages/api/hello.ts
+pages/index.tsx
+README.md
+test/jest.setup.js
+test/pages/index.test.tsx
+tsconfig.json
+tsconfig.ts-jest.json


### PR DESCRIPTION
## Ticket

[WMDP-31](https://wicmtdp.atlassian.net/browse/WMDP-31)

## Changes
1. Added ci.yml to run github action for pass/fail checks when pushing code to remote. Ignores merges (push) to main.
2. Added .prettierignore, which ignores generated files and list of config files see below.

## Context for reviewers
1. Created initial CI.
    - Ensures application successfully builds.
    - Passes all lint checks.
    - Passes format-check checks.
    - Passes test.
2. I decided to ignore configuration files for prettier to allow someone up the chain to decide whether to format them or not.
4. Left out security scanning, it appears that was handled in [WMDP-32](https://wicmtdp.atlassian.net/browse/WMDP-32)
5. Note branch protections need to be configured separately. Three options:
    - Setup manually through website
    - Create 1 shot git cli command using bash
    - Manage branch protections via terraform (my preference)
6. "All of these should run again after “merge” is clicked and any failures should block merging into main." I can set CI to run after merge is clicked, but the merge has already occurred so it wont be able to stop a merge, requiring the status checks to pass before merging should be sufficient for CI. 

## Testing
- Testing was done using [tst-ci-final](https://github.com/shawnvanderjagt/tst-ci-final) in order to keep this repos history clean. Whoever ultimately reviews this just ping me and I will add you as a contributor so you can look at the git histories.
