### PR TITLE
Configure precommit hook to run Next.js linting and formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ How to run:
 3. Run `docker-compose up -d --build` to build the image and start the container.
 4. Navigate to `localhost:3000` in your browser to view the application.
 5. Run `docker-compose down` when you are done to delete the container.
+
+## Git Precommit Hook
+
+We use [husky](https://typicode.github.io/husky/#/) to run linting and formatting checks before each commit. Because our husky directory is in `app`, we configured husky with a [custom directory](https://typicode.github.io/husky/#/?id=custom-directory).

--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -1,5 +1,2 @@
 # This file is run from the same directory as `.git`, so we need to change to the `app` directory to run our husky commands.
-cd app
-yarn lint
-yarn format-check
-yarn ts-check
+cd app && yarn lint && yarn format-check && yarn ts-check

--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -1,3 +1,5 @@
+# This file is run from the same directory as `.git`, so we need to change to the `app` directory to run our husky commands.
+cd app
 yarn lint
 yarn format-check
 yarn ts-check

--- a/app/.husky/pre-commit
+++ b/app/.husky/pre-commit
@@ -1,0 +1,3 @@
+yarn lint
+yarn format-check
+yarn ts-check

--- a/app/package.json
+++ b/app/package.json
@@ -8,9 +8,10 @@
     "format": "prettier --write '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "format-check": "prettier --check '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "lint": "next lint",
+    "postinstall": "cd .. && husky install app/husky",
     "start": "next start",
     "test": "jest --ci --coverage",
-    "ts:check": "tsc --noEmit"
+    "ts-check": "tsc --noEmit"
   },
   "dependencies": {
     "@types/jest-axe": "^3.5.3",
@@ -38,6 +39,7 @@
     "eslint-config-next": "12.1.6",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jest": "^26.5.3",
+    "husky": "^8.0.1",
     "jest": "^28.1.0",
     "jest-cli": "^28.1.0",
     "jest-environment-jsdom": "^28.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "format-check": "prettier --check '**/*.{js,json,md,mdx,ts,tsx,scss,yaml,yml}'",
     "lint": "next lint",
-    "postinstall": "cd .. && husky install app/husky",
+    "postinstall": "cd .. && husky install app/.husky",
     "start": "next start",
     "test": "jest --ci --coverage",
     "ts-check": "tsc --noEmit"

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2471,6 +2471,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"


### PR DESCRIPTION
## Ticket

- https://wicmtdp.atlassian.net/browse/WMDP-34

## Changes
> What was added, updated, or removed in this PR.

- Install [husky](https://typicode.github.io/husky/#/?id=custom-directory) to run `yarn lint && yarn format-check && yarn ts-check` as a precommit git hook to require passing linting and formatting before each git commit
- Install husky as a `yarn postinstall` script after running `yarn install`

### Extras

- Rename `ts:check` script to `ts-check` to match other naming conventions for scripts

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

Adding a git precommit hook for linting and formatting will improve code quality and consistency by preventing malformatted code from being committed and speeding up the development cycle so that a developer knows when a CI job for linting/formatting will fail before they push to Github.

However, using a git precommit hook has two potentially negative consequences:
- Running git commands and the husky install take place outside the docker container on the host machine, which means that `yarn install` **must** be run on the host machine. This adds an extra step to developer setup. 
  - Not sure there is a workaround for this.
- As the precommit hook is currently written, **all** git commits require the linting/formatting checks to be run, even if the changes to the repo are unrelated (e.g. infrastructure changes). 
  - We could write a [custom script](https://stackoverflow.com/questions/67499379/conditionally-running-git-hooks-with-husky) that will only run `yarn` for changes to the `app` directory.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Edit a file so that it breaks formatting/linting rules. For example, edit `pages/_app.tsx` so that the main function is one poorly formatted line: `function MyApp({ Component, pageProps }: AppProps) {return <Component {...pageProps} />       }`
5. Stage your changes: `git add -A .`
6. Attempt to commit your changes: `git commit -m "Test changes."`
7. The commit should display an error and abort
