### PR TITLE
Fix broken link for github.com/new in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The docker-compose file bind mounts `app` on the host machine to `/srv` in the g
 
 The template repository can be used to create a project repository using two different methods.
 
-1. From [Github](https://github.com/): Click [New](github.com/new) and select the desired template.
+1. From [Github](https://github.com/): Click [New](https://github.com/new) and select the desired template.
 2. From the template repo itself: Click "Use this template".
 
 ### These steps are the same for both methods


### PR DESCRIPTION
## Ticket
N/A

## Changes
- Fix broken link for github.com/new in README

## Context for reviewers
The link for creating new repo was a relative link, which means if viewing from the repo's main page it will resolve to `https://github.com/navapbc/template-application-nextjs/blob/main/github.com/new`. This PR fixes it to make it a absolute URL rather than a relative one.

## Testing
Tested by making change in my local editor and clicking on the link in preview mode