### PR TITLE
Remove deprecated packages no longer needed

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -40,8 +40,6 @@
     "@types/node": "^18.0.6",
     "@types/react": "^18.0.9",
     "@types/react-dom": "^18.0.4",
-    "@types/testing-library__jest-dom": "^5.14.3",
-    "@types/testing-library__react": "^10.2.0",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "babel-jest": "^28.1.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -2813,7 +2813,7 @@
     lodash "^4.17.15"
     redent "^3.0.0"
 
-"@testing-library/react@*", "@testing-library/react@^13.2.0":
+"@testing-library/react@^13.2.0":
   version "13.3.0"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-13.3.0.tgz#bf298bfbc5589326bbcc8052b211f3bb097a97c5"
   integrity sha512-DB79aA426+deFgGSjnf5grczDPiL4taK3hFaa+M5q7q20Kcve9eQottOG5kZ74KEr55v0tU2CQormSSDK87zYQ==
@@ -3131,19 +3131,12 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.8.tgz#b94a4391c85666c7b73299fd3ad79d4faa435310"
   integrity sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==
 
-"@types/testing-library__jest-dom@^5.14.3", "@types/testing-library__jest-dom@^5.9.1":
+"@types/testing-library__jest-dom@^5.9.1":
   version "5.14.5"
   resolved "https://registry.yarnpkg.com/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.5.tgz#d113709c90b3c75fdb127ec338dad7d5f86c974f"
   integrity sha512-SBwbxYoyPIvxHbeHxTZX2Pe/74F/tX2/D3mMvzabdeJ25bBojfW0TyB8BHrbq/9zaaKICJZjLP+8r6AeZMFCuQ==
   dependencies:
     "@types/jest" "*"
-
-"@types/testing-library__react@^10.2.0":
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/@types/testing-library__react/-/testing-library__react-10.2.0.tgz#8234be1248ce6728b33922507cfe1224886ede8e"
-  integrity sha512-KbU7qVfEwml8G5KFxM+xEfentAAVj/SOQSjW0+HqzjPE0cXpt0IpSamfX4jGYCImznDHgQcfXBPajS7HjLZduw==
-  dependencies:
-    "@testing-library/react" "*"
 
 "@types/tough-cookie@*":
   version "4.0.2"


### PR DESCRIPTION
## Changes

- Remove `@types/testing-library__...` packages

## Context for reviewers

These packages are deprecated and don't need installed. The `@testing-library/...` packages bundle their own types.

See deprecation notice on https://www.npmjs.com/package/@types/testing-library__dom

<img width="1195" alt="CleanShot 2022-08-31 at 13 58 48@2x" src="https://user-images.githubusercontent.com/371943/187781107-9289f6da-cb48-4963-b654-5f3abf61968b.png">