### PR TITLE
Reduce prettier overrides

### DIFF
--- a/app/.prettierrc.json
+++ b/app/.prettierrc.json
@@ -1,7 +1,5 @@
 {
   "importOrder": ["^components/(.*)$", "^[./]"],
   "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true,
-  "semi": false,
-  "singleQuote": true
+  "importOrderSortSpecifiers": true
 }

--- a/app/.storybook/i18next.js
+++ b/app/.storybook/i18next.js
@@ -1,30 +1,30 @@
 // Configure i18next for storybook addon storybook-react-i18next
 // See https://storybook.js.org/addons/storybook-react-i18next
-import i18n from 'i18next'
-import LanguageDetector from 'i18next-browser-languagedetector'
-import Backend from 'i18next-http-backend'
-import { initReactI18next } from 'react-i18next'
+import i18n from "i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import Backend from "i18next-http-backend";
+import { initReactI18next } from "react-i18next";
 
-const ns = ['common']
-const supportedLngs = ['en', 'es']
+const ns = ["common"];
+const supportedLngs = ["en", "es"];
 const resources = ns.reduce((acc, n) => {
   supportedLngs.forEach((lng) => {
-    if (!acc[lng]) acc[lng] = {}
+    if (!acc[lng]) acc[lng] = {};
     acc[lng] = {
       ...acc[lng],
       [n]: require(`../public/locales/${lng}/${n}.json`),
-    }
-  })
-  return acc
-}, {})
+    };
+  });
+  return acc;
+}, {});
 
 i18n.use(initReactI18next).use(LanguageDetector).use(Backend).init({
-  lng: 'en',
-  fallbackLng: 'en',
-  defaultNS: 'common',
+  lng: "en",
+  fallbackLng: "en",
+  defaultNS: "common",
   ns,
   supportedLngs,
   resources,
-})
+});
 
-export default i18n
+export default i18n;

--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -4,56 +4,56 @@
  * @see https://storybook.js.org/docs/configurations/default-config/
  */
 
-const nextConfig = require('../next.config')
+const nextConfig = require("../next.config");
 
 module.exports = {
-  stories: ['../stories/**/*.stories.@(mdx|js|jsx|ts|tsx)'],
-  addons: ['@storybook/addon-essentials', 'storybook-react-i18next'],
-  framework: '@storybook/react',
+  stories: ["../stories/**/*.stories.@(mdx|js|jsx|ts|tsx)"],
+  addons: ["@storybook/addon-essentials", "storybook-react-i18next"],
+  framework: "@storybook/react",
   core: {
     // Use webpack5 instead of webpack4.
-    builder: 'webpack5',
+    builder: "webpack5",
     disableTelemetry: true,
   },
   // Tell storybook where to find USWDS static assets
-  staticDirs: ['../public'],
+  staticDirs: ["../public"],
 
   // Configure Storybook's final Webpack configuration in order to re-use the Next.js config/dependencies.
   webpackFinal: (config) => {
     config.module?.rules?.push({
       test: /\.scss$/,
       use: [
-        'style-loader',
-        { loader: 'css-loader', options: { url: false } }, // this mirrors next.js behavior
+        "style-loader",
+        { loader: "css-loader", options: { url: false } }, // this mirrors next.js behavior
         {
           /**
            * Next.js sets this automatically for us, but we need to manually set it here for Storybook.
            * The main thing this enables is autoprefixer, so any experimental CSS properties work.
            */
-          loader: 'postcss-loader',
+          loader: "postcss-loader",
           options: {
             postcssOptions: {
-              plugins: ['postcss-preset-env'],
+              plugins: ["postcss-preset-env"],
             },
           },
         },
         {
-          loader: 'sass-loader',
+          loader: "sass-loader",
           options: {
             sassOptions: nextConfig.sassOptions,
           },
         },
       ],
       exclude: /node_modules/,
-    })
+    });
 
     // Required for i18next.
     config.resolve.fallback = {
       fs: false,
       path: false,
       os: false,
-    }
+    };
 
-    return config
+    return config;
   },
-}
+};

--- a/app/.storybook/preview.js
+++ b/app/.storybook/preview.js
@@ -1,10 +1,10 @@
 // Apply global styling to our stories
-import '../styles/styles.scss'
+import "../styles/styles.scss";
 // Import i18next config.
-import i18n from './i18next.js'
+import i18n from "./i18next.js";
 
 export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
+  actions: { argTypesRegex: "^on[A-Z].*" },
   controls: {
     matchers: {
       color: /(background|color)$/i,
@@ -13,9 +13,9 @@ export const parameters = {
   },
   // Configure i18next and locale/dropdown options.
   i18n,
-  locale: 'en',
+  locale: "en",
   locales: {
-    en: 'English',
-    es: 'Español',
+    en: "English",
+    es: "Español",
   },
-}
+};

--- a/app/__mocks__/styleMock.js
+++ b/app/__mocks__/styleMock.js
@@ -1,1 +1,1 @@
-module.exports = {}
+module.exports = {};

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -1,29 +1,29 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'jsdom',
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
   moduleNameMapper: {
-    '\\.(css|scss)$': '<rootDir>/__mocks__/styleMock.js', // sets up routing to mocks style sheet
-    '^@pages(.*)$': '<rootDir>/pages$1', //allows module imports of page components
+    "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js", // sets up routing to mocks style sheet
+    "^@pages(.*)$": "<rootDir>/pages$1", //allows module imports of page components
   },
   setupFilesAfterEnv: [
-    '<rootDir>/tests/jest.setup.js',
-    '<rootDir>/tests/jest-i18n.ts',
+    "<rootDir>/tests/jest.setup.js",
+    "<rootDir>/tests/jest-i18n.ts",
   ],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest',
+    "^.+\\.tsx?$": "ts-jest",
   }, //transfrom typescript files to common js for jest compiler
   transformIgnorePatterns: [
-    '/.next/',
-    '/node_modules/',
-    '^.+\\.module\\.(css|sass|scss)$',
+    "/.next/",
+    "/node_modules/",
+    "^.+\\.module\\.(css|sass|scss)$",
   ],
-  testPathIgnorePatterns: ['<rootDir>/node_modules/'],
-  testRegex: '(/tests/.*(test|spec))\\.[jt]sx?$',
+  testPathIgnorePatterns: ["<rootDir>/node_modules/"],
+  testRegex: "(/tests/.*(test|spec))\\.[jt]sx?$",
   globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.ts-jest.json',
+    "ts-jest": {
+      tsconfig: "tsconfig.ts-jest.json",
     },
   },
-}
+};

--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -1,11 +1,11 @@
 module.exports = {
   i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'es'],
+    defaultLocale: "en",
+    locales: ["en", "es"],
     react: {
       // Add support for <em>.
       // See https://react.i18next.com/latest/trans-component#using-for-less-than-br-greater-than-and-other-simple-html-elements-in-translations-v-10-4-0
-      transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'em'],
+      transKeepBasicHtmlNodesFor: ["br", "strong", "i", "p", "em"],
     },
   },
-}
+};

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,16 +1,16 @@
 /** @type {import('next').NextConfig} */
 
-const { i18n } = require('./next-i18next.config')
+const { i18n } = require("./next-i18next.config");
 
 const nextConfig = {
   i18n,
   reactStrictMode: true,
   sassOptions: {
     includePaths: [
-      './node_modules/@uswds',
-      './node_modules/@uswds/uswds/packages',
+      "./node_modules/@uswds",
+      "./node_modules/@uswds/uswds/packages",
     ],
   },
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/app/src/api/hello.ts
+++ b/app/src/api/hello.ts
@@ -1,13 +1,13 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-import type { NextApiRequest, NextApiResponse } from 'next'
+import type { NextApiRequest, NextApiResponse } from "next";
 
 type Data = {
-  name: string
-}
+  name: string;
+};
 
 export default function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  res.status(200).json({ name: 'John Doe' })
+  res.status(200).json({ name: "John Doe" });
 }

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,24 +1,24 @@
-import { useTranslation } from 'next-i18next'
-import { ReactElement } from 'react'
+import { useTranslation } from "next-i18next";
+import { ReactElement } from "react";
 
 type Props = {
-  children: ReactElement
-}
+  children: ReactElement;
+};
 
 const Layout = ({ children }: Props): ReactElement => {
-  const { t } = useTranslation('common')
+  const { t } = useTranslation("common");
 
   return (
     <div className="container">
       <header className="header">
-        <em>{t('Layout.header')}</em>
+        <em>{t("Layout.header")}</em>
       </header>
       <main className="main">{children}</main>
       <footer className="footer">
-        <em>{t('Layout.footer')}</em>
+        <em>{t("Layout.footer")}</em>
       </footer>
     </div>
-  )
-}
+  );
+};
 
-export default Layout
+export default Layout;

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -1,15 +1,15 @@
-import { appWithTranslation } from 'next-i18next'
-import type { AppProps } from 'next/app'
+import { appWithTranslation } from "next-i18next";
+import type { AppProps } from "next/app";
 
-import '../../styles/styles.scss'
-import Layout from '../components/Layout'
+import "../../styles/styles.scss";
+import Layout from "../components/Layout";
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
     <Layout>
       <Component {...pageProps} />
     </Layout>
-  )
+  );
 }
 
-export default appWithTranslation(MyApp)
+export default appWithTranslation(MyApp);

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,26 +1,26 @@
-import type { GetServerSideProps, NextPage } from 'next'
-import { useTranslation } from 'next-i18next'
-import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import type { GetServerSideProps, NextPage } from "next";
+import { useTranslation } from "next-i18next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 const Home: NextPage = () => {
-  const { t } = useTranslation('common')
+  const { t } = useTranslation("common");
 
   return (
     <h1 className="title">
-      {t('Index.title')}
+      {t("Index.title")}
       <a href="https://github.com/navapbc/template-application-nextjs">
-        {t('Index.titleLink')}
+        {t("Index.titleLink")}
       </a>
     </h1>
-  )
-}
+  );
+};
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   return {
     props: {
-      ...(await serverSideTranslations(locale || 'en', ['common'])),
+      ...(await serverSideTranslations(locale || "en", ["common"])),
     },
-  }
-}
+  };
+};
 
-export default Home
+export default Home;

--- a/app/stories/components/Layout.stories.tsx
+++ b/app/stories/components/Layout.stories.tsx
@@ -1,16 +1,16 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import LayoutComponent from '../../src/components/Layout'
+import LayoutComponent from "../../src/components/Layout";
 
 export default {
-  title: 'Components',
+  title: "Components",
   component: LayoutComponent,
-} as ComponentMeta<typeof LayoutComponent>
+} as ComponentMeta<typeof LayoutComponent>;
 
 const Template: ComponentStory<typeof LayoutComponent> = () => (
   <LayoutComponent>
     <h1>Child</h1>
   </LayoutComponent>
-)
+);
 
-export const Layout = Template.bind({})
+export const Layout = Template.bind({});

--- a/app/stories/pages/Index.stories.tsx
+++ b/app/stories/pages/Index.stories.tsx
@@ -1,12 +1,12 @@
-import { ComponentMeta, ComponentStory } from '@storybook/react'
+import { ComponentMeta, ComponentStory } from "@storybook/react";
 
-import Index from '../../src/pages/index'
+import Index from "../../src/pages/index";
 
 export default {
-  title: 'Pages',
+  title: "Pages",
   component: Index,
-} as ComponentMeta<typeof Index>
+} as ComponentMeta<typeof Index>;
 
-const Template: ComponentStory<typeof Index> = () => <Index />
+const Template: ComponentStory<typeof Index> = () => <Index />;
 
-export const Home = Template.bind({})
+export const Home = Template.bind({});

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -20,7 +20,7 @@ i.e.
 ----------------------------------------
 */
 
-@use 'uswds-core' as *;
+@use "uswds-core" as *;
 
 .container {
   min-height: 100vh;

--- a/app/styles/_uswds-theme.scss
+++ b/app/styles/_uswds-theme.scss
@@ -7,12 +7,12 @@ in the form $setting: value,
 ----------------------------------------
 */
 
-@use 'uswds-core' with (
+@use "uswds-core" with (
   // Disable scary but mostly irrelevant warnings:
   $theme-show-notifications: false,
 
   // Specify USWDS font and image paths.
   // Same paths are successfully used for both Next.js and Storybook.
-  $theme-font-path: '/uswds/fonts',
-  $theme-image-path: '/uswds/img'
+  $theme-font-path: "/uswds/fonts",
+  $theme-image-path: "/uswds/img"
 );

--- a/app/styles/styles.scss
+++ b/app/styles/styles.scss
@@ -1,3 +1,3 @@
-@forward 'uswds-theme';
-@forward 'uswds';
-@forward 'uswds-theme-custom-styles';
+@forward "uswds-theme";
+@forward "uswds";
+@forward "uswds-theme-custom-styles";

--- a/app/tests/components/Layout.test.tsx
+++ b/app/tests/components/Layout.test.tsx
@@ -1,31 +1,31 @@
 // test/pages/index.test.js
-import { render, screen } from '@testing-library/react'
-import { axe } from 'jest-axe'
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
 
-import Layout from '../../src/components/Layout'
+import Layout from "../../src/components/Layout";
 
-describe('Layout', () => {
-  it('should render placeholder header text', () => {
+describe("Layout", () => {
+  it("should render placeholder header text", () => {
     render(
       <Layout>
         <h1>"child"</h1>
       </Layout>
-    )
+    );
 
-    const header = screen.getByText(/Template Header/i)
+    const header = screen.getByText(/Template Header/i);
 
-    expect(header).toBeInTheDocument()
-    expect(header).toMatchSnapshot()
-  })
+    expect(header).toBeInTheDocument();
+    expect(header).toMatchSnapshot();
+  });
 
-  it('should pass accessibility scan', async () => {
+  it("should pass accessibility scan", async () => {
     const { container } = render(
       <Layout>
         <h1>"child"</h1>
       </Layout>
-    )
-    const results = await axe(container)
+    );
+    const results = await axe(container);
 
-    expect(results).toHaveNoViolations()
-  })
-})
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/app/tests/jest-i18n.ts
+++ b/app/tests/jest-i18n.ts
@@ -1,22 +1,22 @@
-import i18n from 'i18next'
-import { initReactI18next } from 'react-i18next'
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
 
-import enCommon from '../public/locales/en/common.json'
-import esCommon from '../public/locales/es/common.json'
+import enCommon from "../public/locales/en/common.json";
+import esCommon from "../public/locales/es/common.json";
 
 // Setup react-i18next for tests. Load actual content along with some mocked content.
 i18n.use(initReactI18next).init({
-  fallbackLng: 'en',
-  ns: ['common'],
-  defaultNS: 'common',
+  fallbackLng: "en",
+  ns: ["common"],
+  defaultNS: "common",
   resources: {
     en: {
       common: enCommon,
     },
     es: { common: esCommon },
   },
-})
+});
 
 // Export i18n so tests can manually set the lanuage with:
 // i18n.changeLanguage('es')
-export default i18n
+export default i18n;

--- a/app/tests/jest.setup.js
+++ b/app/tests/jest.setup.js
@@ -1,4 +1,4 @@
-require('@testing-library/jest-dom')
-const { toHaveNoViolations } = require('jest-axe')
+require("@testing-library/jest-dom");
+const { toHaveNoViolations } = require("jest-axe");
 
-expect.extend(toHaveNoViolations)
+expect.extend(toHaveNoViolations);

--- a/app/tests/pages/index.test.tsx
+++ b/app/tests/pages/index.test.tsx
@@ -1,23 +1,23 @@
 // test/pages/index.test.js
-import { render, screen } from '@testing-library/react'
-import { axe } from 'jest-axe'
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
 
-import Index from '../../src/pages/index'
+import Index from "../../src/pages/index";
 
-describe('Index', () => {
-  it('should render the heading', () => {
-    render(<Index />)
+describe("Index", () => {
+  it("should render the heading", () => {
+    render(<Index />);
 
-    const heading = screen.getByText(/Welcome/i)
+    const heading = screen.getByText(/Welcome/i);
 
-    expect(heading).toBeInTheDocument()
-    expect(heading).toMatchSnapshot()
-  })
+    expect(heading).toBeInTheDocument();
+    expect(heading).toMatchSnapshot();
+  });
 
-  it('should pass accessibility scan', async () => {
-    const { container } = render(<Index />)
-    const results = await axe(container)
+  it("should pass accessibility scan", async () => {
+    const { container } = render(<Index />);
+    const results = await axe(container);
 
-    expect(results).toHaveNoViolations()
-  })
-})
+    expect(results).toHaveNoViolations();
+  });
+});


### PR DESCRIPTION
## Ticket

#24 

## Changes
This PR removed some non-default settings for prettier and then also made the formatting changes associated with that setting change. The setting change and the format change are in separate commits, in case that makes it easier to review.

## Context for reviewers
All changes should be non-functional, so just visual confirmation that this looks right is probably all that's needed. Rationale for the change is provided in the issue (#24).

## Testing
Non-functional changes, so little testing was needed, but I still ran storybook and the next.js app to make sure those still work, and they did.
