### PR TITLE
Remove non-uswds style elements from template

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -8,7 +8,13 @@ First, install dependencies from the app directory:
 npm install
 ```
 
-Second, run the development server:
+If desired, run the tests:
+
+```bash
+npm test
+```
+
+Then, run the development server:
 
 ```bash
 npm run dev

--- a/app/README.md
+++ b/app/README.md
@@ -8,13 +8,7 @@ First, install dependencies from the app directory:
 npm install
 ```
 
-If desired, run the tests:
-
-```bash
-npm test
-```
-
-Then, run the development server:
+Second, run the development server:
 
 ```bash
 npm run dev
@@ -67,6 +61,8 @@ Note: make sure TypeScript and Javascript Language Features are enabled in VS Co
 ### Package.json
 
 #### Scripts
+
+These can be run with `npm run [name of script]`.
 
 - `format`: instructs prettier to rewrite files with fixes for formatting violations.
 - `format-check`: instructs prettier to only check files for violations without fixing them.

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -9,8 +9,8 @@ const Layout = ({ children }: Props): ReactElement => {
   const { t } = useTranslation("common");
 
   return (
-    <div className="container">
-      <header /* add your agency's header class here */>
+    <div>
+      <header /* add your agency's or USWDS's header here */>
         <em>{t("Layout.header")}</em>
       </header>
       <main className="grid-container">
@@ -18,7 +18,7 @@ const Layout = ({ children }: Props): ReactElement => {
           <div className="grid-col">{children}</div>
         </div>
       </main>
-      <footer /* add your agency's footer class here */>
+      <footer /* add your agency's or USWDS's footer here */>
         <em>{t("Layout.footer")}</em>
       </footer>
     </div>

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -10,11 +10,15 @@ const Layout = ({ children }: Props): ReactElement => {
 
   return (
     <div className="container">
-      <header className="header">
+      <header /*add your agency's header class here*/>
         <em>{t("Layout.header")}</em>
       </header>
-      <main className="main">{children}</main>
-      <footer className="footer">
+      <main className="grid-container">
+        <div className="grid-row">
+          <div className="grid-col">{children}</div>
+        </div>
+      </main>
+      <footer /*add your agency's footer class here*/>
         <em>{t("Layout.footer")}</em>
       </footer>
     </div>

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -10,7 +10,7 @@ const Layout = ({ children }: Props): ReactElement => {
 
   return (
     <div className="container">
-      <header /*add your agency's header class here*/>
+      <header /* add your agency's header class here */>
         <em>{t("Layout.header")}</em>
       </header>
       <main className="grid-container">
@@ -18,7 +18,7 @@ const Layout = ({ children }: Props): ReactElement => {
           <div className="grid-col">{children}</div>
         </div>
       </main>
-      <footer /*add your agency's footer class here*/>
+      <footer /* add your agency's footer class here */>
         <em>{t("Layout.footer")}</em>
       </footer>
     </div>

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -6,7 +6,7 @@ const Home: NextPage = () => {
   const { t } = useTranslation("common");
 
   return (
-    <h1 className="title">
+    <h1>
       {t("Index.title")}
       <a href="https://github.com/navapbc/template-application-nextjs">
         {t("Index.titleLink")}

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -28,37 +28,6 @@ i.e.
   flex-direction: column;
 }
 
-.header {
-  align-items: center;
-  border-bottom: 1px solid #eaeaea;
-  display: flex;
-  justify-content: center;
-  padding: 2rem;
-  position: sticky;
-  top: 0;
-}
-
-.footer {
-  align-items: center;
-  background-color: rgb(250, 250, 250);
-  border-top: 1px solid #eaeaea;
-  bottom: 0;
-  justify-content: center;
-  padding: 2rem;
-  position: sticky;
-  display: flex;
-  width: 100%;
-}
-
-.main {
-  align-items: center;
-  background: linear-gradient(white, rgb(237, 234, 244));
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  padding: 2rem;
-}
-
 .title a {
   text-decoration: none;
 }

--- a/app/styles/_uswds-theme-custom-styles.scss
+++ b/app/styles/_uswds-theme-custom-styles.scss
@@ -21,19 +21,3 @@ i.e.
 */
 
 @use "uswds-core" as *;
-
-.container {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-}
-
-.title a {
-  text-decoration: none;
-}
-
-.title a:hover,
-.title a:focus,
-.title a:active {
-  text-decoration: underline;
-}

--- a/app/tests/pages/__snapshots__/index.test.tsx.snap
+++ b/app/tests/pages/__snapshots__/index.test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Index should render the heading 1`] = `
-<h1
-  class="title"
->
+<h1>
   Welcome to your 
   <a
     href="https://github.com/navapbc/template-application-nextjs"


### PR DESCRIPTION
## Ticket

Resolves #18 

## Changes
These changes removed many of the custom style elements from the template. There was also a minor update to the readme file to help new users run the test script.

## Context for reviewers
Details in #18; while these changes make the template look slightly less polished, the intention was to allow users of this template to use their own style elements, either from uswds or from their agency, without needing to pull out or overwrite custom style elements from the template.

## Testing
```
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
Snapshots:   2 passed, 2 total
Time:        1.128 s
Ran all test suites.
```

Before:
<img width="1401" alt="Screen Shot 2022-10-04 at 5 14 47 PM" src="https://user-images.githubusercontent.com/90421499/193953119-d65f3349-fbe2-4f47-be0a-ff484eba8152.png">

After:
<img width="1400" alt="Screen Shot 2022-10-04 at 5 14 26 PM" src="https://user-images.githubusercontent.com/90421499/193953164-a465dd7d-177b-4a05-84ba-830b2aa3b988.png">
