### PR TITLE
Support locale reloading during local dev

### DIFF
--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -8,4 +8,8 @@ module.exports = {
       transKeepBasicHtmlNodesFor: ["br", "strong", "i", "p", "em"],
     },
   },
+  // Locale resources are loaded once when the server is started, which
+  // is good for production but not ideal for local development. Show
+  // updates to locale files without having to restart the server:
+  reloadOnPrerender: process.env.NODE_ENV === "development",
 };


### PR DESCRIPTION
## Changes

- Enable the `reloadOnPrerender` option of `next-i18next` when running the app locally. This will allow developers to edit `public/locales/` files and reload their browser to see the changes. Prior to this, you would need to restart the server and then reload the page, which is a fairly big impact to productivity depending on the dev's workflow.

## Testing

![CleanShot 2022-10-19 at 10 33 44](https://user-images.githubusercontent.com/371943/196763985-902b3b35-e582-450d-ab4b-6231c59e41e8.gif)

