### PR TITLE
Expand usage documation for internationalization

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -136,22 +136,6 @@ Compiling the USWDS sass is slow, so the initial build step and subsequent sass 
 
 Copying the USWDS static assets into the project is handled by a [`postinstall`](https://docs.npmjs.com/cli/v8/using-npm/scripts) script in `package.json`.
 
-## Internationalization (i18n)
+## Other topics
 
-Configuration is located in [`next-i18next.config.js`](./next-i18next.config.js).
-
-- Next.js's [internationalized routing](https://nextjs.org/docs/advanced-features/i18n-routing) feature is enabled.
-- [`next-i18next`](https://github.com/i18next/next-i18next) provides a method for loading translations and a hook for rendering localized strings using [`react-i18next`](https://github.com/i18next/react-i18next).
-
-### Adding a language
-
-1. Edit `next-i18next.config.js` and add the language to `locales`
-1. Add a language folder: `mkdir -p public/locales/<lang>`
-1. Add a language file: `touch public/locales/<lang>/common.json` and add the translated content
-1. Optionally, add a label for the language to the `locales` object in [`.storybook/preview.js`](./.storybook/preview.js)
-
-The JSON structure should be the same across languages. However, non-default languages can omit keys, in which case the translation content for the default language will be used.
-
-### Storybook i18n
-
-[storybook-react-i18next](https://storybook.js.org/addons/storybook-react-i18next) adds a globe icon to the addons bar for selecting the desired language.
+- [Internationalization](../docs/internationalization.md)

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,5 +1,5 @@
-import { useTranslation } from "next-i18next";
 import { ReactElement } from "react";
+import { useTranslation } from "react-i18next";
 
 type Props = {
   children: ReactElement;

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { GetServerSideProps, NextPage } from "next";
-import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { Trans, useTranslation } from "react-i18next";
 
 const Home: NextPage = () => {
   const { t } = useTranslation("common");
@@ -9,18 +9,15 @@ const Home: NextPage = () => {
     <h1>
       {t("Index.title")}
       <a href="https://github.com/navapbc/template-application-nextjs">
-        {t("Index.titleLink")}
+        <Trans i18nKey="Index.titleLink" />
       </a>
     </h1>
   );
 };
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
-  return {
-    props: {
-      ...(await serverSideTranslations(locale || "en", ["common"])),
-    },
-  };
+  const translations = await serverSideTranslations(locale ?? "en");
+  return { props: { ...translations } };
 };
 
 export default Home;

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,6 +1,6 @@
 import type { GetServerSideProps, NextPage } from "next";
+import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
-import { Trans, useTranslation } from "react-i18next";
 
 const Home: NextPage = () => {
   const { t } = useTranslation("common");
@@ -9,7 +9,7 @@ const Home: NextPage = () => {
     <h1>
       {t("Index.title")}
       <a href="https://github.com/navapbc/template-application-nextjs">
-        <Trans i18nKey="Index.titleLink" />
+        {t("Index.titleLink")}
       </a>
     </h1>
   );

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -15,6 +15,7 @@ const Home: NextPage = () => {
   );
 };
 
+// Change this to getStaticProps if you're not using server-side rendering
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
   const translations = await serverSideTranslations(locale ?? "en");
   return { props: { ...translations } };

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -1,0 +1,56 @@
+# Internationalization (i18n)
+
+- [I18next](https://www.i18next.com/) is used for internationalization.
+- Next.js's [internationalized routing](https://nextjs.org/docs/advanced-features/i18n-routing) feature is enabled. Toggling between languages is done by changing the URL's path prefix (e.g. `/about` ➡️ `/es/about`).
+- Configuration for the i18n routing and i18next libraries are located in [`next-i18next.config.js`](../app/next-i18next.config.js).
+- [storybook-react-i18next](https://storybook.js.org/addons/storybook-react-i18next) adds a globe icon to Storybook's toolbar for toggling languages.
+
+## Managing translations
+
+- Translations are managed in the `public/locales` directory, where each language has its own directory (e.g. `en` and `es`).
+- [Namespaces](https://www.i18next.com/principles/namespaces) can be used to organize translations into smaller files. For large sites, it's common to create a namespace for each controller, page, or feature (whatever level makes most sense).
+- There are a number of built-in formatters based on [JS's `Intl` API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) that can be used in locale strings, and custom formatters can be added as well. [See the i18next formatting docs for details](https://www.i18next.com/translation-function/formatting#built-in-formats).
+
+## Load translations
+
+1. `serverSideTranslations` must be called in [`getStaticProps`](https://nextjs.org/docs/basic-features/data-fetching/get-static-props) or [`getServerSideProps`](https://nextjs.org/docs/basic-features/data-fetching/get-server-side-props) to load translations for a page.
+
+   ```tsx
+   import type { GetServerSideProps } from "next";
+   import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+
+   export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+     // serverSideTranslations takes an optional second argument to limit
+     // which namespaces are sent to the client
+     const translations = await serverSideTranslations(locale ?? "en");
+     return { props: { ...translations } };
+   };
+   ```
+
+   Note that `serverSideTranslations` needs imported in the same file as the `getServerSideProps` / `getStaticProps` function, so that Next.js properly excludes it from the client-side bundle, where Node.js APIs (e.g. `fs`) aren't available.
+
+1. Then use the `useTranslation` hook's `t()` method, or the `Trans` component to render localized strings.
+
+   ```tsx
+   import { Trans, useTranslation } from "react-i18next";
+
+   const Page = () => {
+     // Optionally pass in the namespace of the translation file (e.g. common) to use
+     const { t } = useTranslation("common");
+     return (
+       <>
+         <h1>{t("About.title")}</h1>
+         <Trans i18nKey="About.summary" />
+       </>
+     );
+   };
+   ```
+
+Refer to the [i18next](https://www.i18next.com/) and [react-i18next](https://react.i18next.com/) documentation for more usage docs.
+
+## Add a new language
+
+1. Edit `next-i18next.config.js` and add the language to `locales`, using the BCP47 language tag (e.g. `en` or `es`).
+1. Add a language folder, using the same BCP47 language tag: `mkdir -p public/locales/<lang>`
+1. Add a language file: `touch public/locales/<lang>/common.json` and add the translated content. The JSON structure should be the same across languages. However, non-default languages can omit keys, in which case the default language will be used as a fallback.
+1. Optionally, add a label for the language to the `locales` object in [`.storybook/preview.js`](../app/.storybook/preview.js)


### PR DESCRIPTION
## Ticket

#22 

## Changes

- Split out Internationalization documentation into its own file and added additional usage documentation
- Import `useTranslation` from `react-i18next` instead of `next-i18next`. Primary reasoning is because `next-i18next` is just returning the methods from `react-i18next`, and I think it'll be clearer to engineers where they should search for relevant documentation if the import is from the library that's providing the methods.
