### PR TITLE
Upgrade to Next.js 13

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@uswds/uswds": "^3.1.0",
         "i18next": "^21.9.2",
-        "next": "^12.3.1",
+        "next": "^13.0.1",
         "next-i18next": "^12.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -36,7 +36,7 @@
         "@typescript-eslint/parser": "^5.39.0",
         "eslint": "^8.24.0",
         "eslint-config-nava": "^11.0.0",
-        "eslint-config-next": "^12.3.1",
+        "eslint-config-next": "^13.0.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-jest": "^27.1.1",
         "eslint-plugin-storybook": "^0.6.4",
@@ -4164,14 +4164,14 @@
       "dev": true
     },
     "node_modules/@next/env": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.1.tgz",
+      "integrity": "sha512-gK60YoFae3s8qi5UgIzbvxOhsh5gKyEaiKH5+kLBUYXLlrPyWJR2xKBj2WqvHkO7wDX7/Hed3DAqjSpU4ijIvQ=="
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.1.tgz",
-      "integrity": "sha512-sw+lTf6r6P0j+g/n9y4qdWWI2syPqZx+uc0+B/fRENqfR3KpSid6MIKqc9gNwGhJASazEQ5b3w8h4cAET213jw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.0.1.tgz",
+      "integrity": "sha512-t3bggJhKE/oB4pvMM7hMNnmIpIqsMGJ+OLklk8llOkSeXtfCV+MBQbhImWxf5QODkxNAmMK3IJGAAecQhBTc/Q==",
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
@@ -4198,9 +4198,9 @@
       }
     },
     "node_modules/@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.1.tgz",
+      "integrity": "sha512-M28QSbohZlNXNn//HY6lV2T3YaMzG58Jwr0YwOdVmOQv6i+7lu6xe3GqQu4kdqInqhLrBXnL+nabFuGTVSHtTg==",
       "cpu": [
         "arm"
       ],
@@ -4213,9 +4213,9 @@
       }
     },
     "node_modules/@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.1.tgz",
+      "integrity": "sha512-szmO/i6GoHcPXcbhUKhwBMETWHNXH3ITz9wfxwOOFBNKdDU8pjKsHL88lg28aOiQYZSU1sxu1v1p9KY5kJIZCg==",
       "cpu": [
         "arm64"
       ],
@@ -4228,9 +4228,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.1.tgz",
+      "integrity": "sha512-O1RxCaiDNOjGZmdAp6SQoHUITt9aVDQXoR3lZ/TloI/NKRAyAV4u0KUUofK+KaZeHOmVTnPUaQuCyZSc3i1x5Q==",
       "cpu": [
         "arm64"
       ],
@@ -4243,9 +4243,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.1.tgz",
+      "integrity": "sha512-8E6BY/VO+QqQkthhoWgB8mJMw1NcN9Vhl2OwEwxv8jy2r3zjeU+WNRxz4y8RLbcY0R1h+vHlXuP0mLnuac84tQ==",
       "cpu": [
         "x64"
       ],
@@ -4258,9 +4258,9 @@
       }
     },
     "node_modules/@next/swc-freebsd-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.1.tgz",
+      "integrity": "sha512-ocwoOxm2KVwF50RyoAT+2RQPLlkyoF7sAqzMUVgj+S6+DTkY3iwH+Zpo0XAk2pnqT9qguOrKnEpq9EIx//+K7Q==",
       "cpu": [
         "x64"
       ],
@@ -4273,9 +4273,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.1.tgz",
+      "integrity": "sha512-yO7e3zITfGol/N6lPQnmIRi0WyuILBMXrvH6EdmWzzqMDJFfTCII6l+B6gMO5WVDCTQUGQlQRNZ7sFqWR4I71g==",
       "cpu": [
         "arm"
       ],
@@ -4288,9 +4288,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.1.tgz",
+      "integrity": "sha512-OEs6WDPDI8RyM8SjOqTDMqMBfOlU97VnW6ZMXUvzUTyH0K9c7NF+cn7UMu+I4tKFN0uJ9WQs/6TYaFBGkgoVVA==",
       "cpu": [
         "arm64"
       ],
@@ -4303,9 +4303,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.1.tgz",
+      "integrity": "sha512-y5ypFK0Y3urZSFoQxbtDqvKsBx026sz+Fm+xHlPWlGHNZrbs3Q812iONjcZTo09QwRMk5X86iMWBRxV18xMhaw==",
       "cpu": [
         "arm64"
       ],
@@ -4318,9 +4318,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.1.tgz",
+      "integrity": "sha512-XDIHEE6SU8VCF+dUVntD6PDv6RK31N0forx9kucZBYirbe8vCZ+Yx8hYgvtIaGrTcWtGxibxmND0pIuHDq8H5g==",
       "cpu": [
         "x64"
       ],
@@ -4333,9 +4333,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.1.tgz",
+      "integrity": "sha512-yxIOuuz5EOx0F1FDtsyzaLgnDym0Ysxv8CWeJyDTKKmt9BVyITg6q/cD+RP9bEkT1TQi+PYXIMATSz675Q82xw==",
       "cpu": [
         "x64"
       ],
@@ -4348,9 +4348,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.1.tgz",
+      "integrity": "sha512-+ucLe2qgQzP+FM94jD4ns6LDGyMFaX9k3lVHqu/tsQCy2giMymbport4y4p77mYcXEMlDaHMzlHgOQyHRniWFA==",
       "cpu": [
         "arm64"
       ],
@@ -4363,9 +4363,9 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.1.tgz",
+      "integrity": "sha512-Krr/qGN7OB35oZuvMAZKoXDt2IapynIWLh5A5rz6AODb7f/ZJqyAuZSK12vOa2zKdobS36Qm4IlxxBqn9c00MA==",
       "cpu": [
         "ia32"
       ],
@@ -4378,9 +4378,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.1.tgz",
+      "integrity": "sha512-t/0G33t/6VGWZUGCOT7rG42qqvf/x+MrFp1CU+8CN6PrjSSL57R5bqkXfubV9t4eCEnUxVP+5Hn3MoEXEebtEw==",
       "cpu": [
         "x64"
       ],
@@ -14207,6 +14207,11 @@
         "@colors/colors": "1.5.0"
       }
     },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -16099,12 +16104,12 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.1.tgz",
-      "integrity": "sha512-EN/xwKPU6jz1G0Qi6Bd/BqMnHLyRAL0VsaQaWA7F3KkjAgZHi4f1uL1JKGWNxdQpHTW/sdGONBd0bzxUka/DJg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.0.1.tgz",
+      "integrity": "sha512-/N9UpSwkbEMj5pIiB235p7QHaSW08ta/iKVaIHF44wufxr+PuJVLwg5LzlAaQbmCZCBpYvVttl3ZxTusP1g2sg==",
       "dev": true,
       "dependencies": {
-        "@next/eslint-plugin-next": "12.3.1",
+        "@next/eslint-plugin-next": "13.0.1",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -24536,43 +24541,43 @@
       "dev": true
     },
     "node_modules/next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.1.tgz",
+      "integrity": "sha512-ErCNBPIeZMKFn6hX+ZBSlqZVgJIeitEqhGTuQUNmYXJ07/A71DZ7AJI8eyHYUdBb686LUpV1/oBdTq9RpzRVPg==",
       "dependencies": {
-        "@next/env": "12.3.1",
+        "@next/env": "13.0.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       },
       "bin": {
         "next": "dist/bin/next"
       },
       "engines": {
-        "node": ">=12.22.0"
+        "node": ">=14.6.0"
       },
       "optionalDependencies": {
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1"
+        "@next/swc-android-arm-eabi": "13.0.1",
+        "@next/swc-android-arm64": "13.0.1",
+        "@next/swc-darwin-arm64": "13.0.1",
+        "@next/swc-darwin-x64": "13.0.1",
+        "@next/swc-freebsd-x64": "13.0.1",
+        "@next/swc-linux-arm-gnueabihf": "13.0.1",
+        "@next/swc-linux-arm64-gnu": "13.0.1",
+        "@next/swc-linux-arm64-musl": "13.0.1",
+        "@next/swc-linux-x64-gnu": "13.0.1",
+        "@next/swc-linux-x64-musl": "13.0.1",
+        "@next/swc-win32-arm64-msvc": "13.0.1",
+        "@next/swc-win32-ia32-msvc": "13.0.1",
+        "@next/swc-win32-x64-msvc": "13.0.1"
       },
       "peerDependencies": {
         "fibers": ">= 3.1.0",
         "node-sass": "^6.0.0 || ^7.0.0",
-        "react": "^17.0.2 || ^18.0.0-0",
-        "react-dom": "^17.0.2 || ^18.0.0-0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
         "sass": "^1.3.0"
       },
       "peerDependenciesMeta": {
@@ -29214,9 +29219,12 @@
       }
     },
     "node_modules/styled-jsx": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -34250,14 +34258,14 @@
       }
     },
     "@next/env": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-12.3.1.tgz",
-      "integrity": "sha512-9P9THmRFVKGKt9DYqeC2aKIxm8rlvkK38V1P1sRE7qyoPBIs8l9oo79QoSdPtOWfzkbDAVUqvbQGgTMsb8BtJg=="
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-13.0.1.tgz",
+      "integrity": "sha512-gK60YoFae3s8qi5UgIzbvxOhsh5gKyEaiKH5+kLBUYXLlrPyWJR2xKBj2WqvHkO7wDX7/Hed3DAqjSpU4ijIvQ=="
     },
     "@next/eslint-plugin-next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-12.3.1.tgz",
-      "integrity": "sha512-sw+lTf6r6P0j+g/n9y4qdWWI2syPqZx+uc0+B/fRENqfR3KpSid6MIKqc9gNwGhJASazEQ5b3w8h4cAET213jw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-13.0.1.tgz",
+      "integrity": "sha512-t3bggJhKE/oB4pvMM7hMNnmIpIqsMGJ+OLklk8llOkSeXtfCV+MBQbhImWxf5QODkxNAmMK3IJGAAecQhBTc/Q==",
       "dev": true,
       "requires": {
         "glob": "7.1.7"
@@ -34280,81 +34288,81 @@
       }
     },
     "@next/swc-android-arm-eabi": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-12.3.1.tgz",
-      "integrity": "sha512-i+BvKA8tB//srVPPQxIQN5lvfROcfv4OB23/L1nXznP+N/TyKL8lql3l7oo2LNhnH66zWhfoemg3Q4VJZSruzQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm-eabi/-/swc-android-arm-eabi-13.0.1.tgz",
+      "integrity": "sha512-M28QSbohZlNXNn//HY6lV2T3YaMzG58Jwr0YwOdVmOQv6i+7lu6xe3GqQu4kdqInqhLrBXnL+nabFuGTVSHtTg==",
       "optional": true
     },
     "@next/swc-android-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-12.3.1.tgz",
-      "integrity": "sha512-CmgU2ZNyBP0rkugOOqLnjl3+eRpXBzB/I2sjwcGZ7/Z6RcUJXK5Evz+N0ucOxqE4cZ3gkTeXtSzRrMK2mGYV8Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-android-arm64/-/swc-android-arm64-13.0.1.tgz",
+      "integrity": "sha512-szmO/i6GoHcPXcbhUKhwBMETWHNXH3ITz9wfxwOOFBNKdDU8pjKsHL88lg28aOiQYZSU1sxu1v1p9KY5kJIZCg==",
       "optional": true
     },
     "@next/swc-darwin-arm64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-12.3.1.tgz",
-      "integrity": "sha512-hT/EBGNcu0ITiuWDYU9ur57Oa4LybD5DOQp4f22T6zLfpoBMfBibPtR8XktXmOyFHrL/6FC2p9ojdLZhWhvBHg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.0.1.tgz",
+      "integrity": "sha512-O1RxCaiDNOjGZmdAp6SQoHUITt9aVDQXoR3lZ/TloI/NKRAyAV4u0KUUofK+KaZeHOmVTnPUaQuCyZSc3i1x5Q==",
       "optional": true
     },
     "@next/swc-darwin-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-12.3.1.tgz",
-      "integrity": "sha512-9S6EVueCVCyGf2vuiLiGEHZCJcPAxglyckTZcEwLdJwozLqN0gtS0Eq0bQlGS3dH49Py/rQYpZ3KVWZ9BUf/WA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.0.1.tgz",
+      "integrity": "sha512-8E6BY/VO+QqQkthhoWgB8mJMw1NcN9Vhl2OwEwxv8jy2r3zjeU+WNRxz4y8RLbcY0R1h+vHlXuP0mLnuac84tQ==",
       "optional": true
     },
     "@next/swc-freebsd-x64": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.3.1.tgz",
-      "integrity": "sha512-qcuUQkaBZWqzM0F1N4AkAh88lLzzpfE6ImOcI1P6YeyJSsBmpBIV8o70zV+Wxpc26yV9vpzb+e5gCyxNjKJg5Q==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-13.0.1.tgz",
+      "integrity": "sha512-ocwoOxm2KVwF50RyoAT+2RQPLlkyoF7sAqzMUVgj+S6+DTkY3iwH+Zpo0XAk2pnqT9qguOrKnEpq9EIx//+K7Q==",
       "optional": true
     },
     "@next/swc-linux-arm-gnueabihf": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-12.3.1.tgz",
-      "integrity": "sha512-diL9MSYrEI5nY2wc/h/DBewEDUzr/DqBjIgHJ3RUNtETAOB3spMNHvJk2XKUDjnQuluLmFMloet9tpEqU2TT9w==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm-gnueabihf/-/swc-linux-arm-gnueabihf-13.0.1.tgz",
+      "integrity": "sha512-yO7e3zITfGol/N6lPQnmIRi0WyuILBMXrvH6EdmWzzqMDJFfTCII6l+B6gMO5WVDCTQUGQlQRNZ7sFqWR4I71g==",
       "optional": true
     },
     "@next/swc-linux-arm64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-12.3.1.tgz",
-      "integrity": "sha512-o/xB2nztoaC7jnXU3Q36vGgOolJpsGG8ETNjxM1VAPxRwM7FyGCPHOMk1XavG88QZSQf+1r+POBW0tLxQOJ9DQ==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.0.1.tgz",
+      "integrity": "sha512-OEs6WDPDI8RyM8SjOqTDMqMBfOlU97VnW6ZMXUvzUTyH0K9c7NF+cn7UMu+I4tKFN0uJ9WQs/6TYaFBGkgoVVA==",
       "optional": true
     },
     "@next/swc-linux-arm64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-12.3.1.tgz",
-      "integrity": "sha512-2WEasRxJzgAmP43glFNhADpe8zB7kJofhEAVNbDJZANp+H4+wq+/cW1CdDi8DqjkShPEA6/ejJw+xnEyDID2jg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.0.1.tgz",
+      "integrity": "sha512-y5ypFK0Y3urZSFoQxbtDqvKsBx026sz+Fm+xHlPWlGHNZrbs3Q812iONjcZTo09QwRMk5X86iMWBRxV18xMhaw==",
       "optional": true
     },
     "@next/swc-linux-x64-gnu": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-12.3.1.tgz",
-      "integrity": "sha512-JWEaMyvNrXuM3dyy9Pp5cFPuSSvG82+yABqsWugjWlvfmnlnx9HOQZY23bFq3cNghy5V/t0iPb6cffzRWylgsA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.0.1.tgz",
+      "integrity": "sha512-XDIHEE6SU8VCF+dUVntD6PDv6RK31N0forx9kucZBYirbe8vCZ+Yx8hYgvtIaGrTcWtGxibxmND0pIuHDq8H5g==",
       "optional": true
     },
     "@next/swc-linux-x64-musl": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-12.3.1.tgz",
-      "integrity": "sha512-xoEWQQ71waWc4BZcOjmatuvPUXKTv6MbIFzpm4LFeCHsg2iwai0ILmNXf81rJR+L1Wb9ifEke2sQpZSPNz1Iyg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.0.1.tgz",
+      "integrity": "sha512-yxIOuuz5EOx0F1FDtsyzaLgnDym0Ysxv8CWeJyDTKKmt9BVyITg6q/cD+RP9bEkT1TQi+PYXIMATSz675Q82xw==",
       "optional": true
     },
     "@next/swc-win32-arm64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-12.3.1.tgz",
-      "integrity": "sha512-hswVFYQYIeGHE2JYaBVtvqmBQ1CppplQbZJS/JgrVI3x2CurNhEkmds/yqvDONfwfbttTtH4+q9Dzf/WVl3Opw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.0.1.tgz",
+      "integrity": "sha512-+ucLe2qgQzP+FM94jD4ns6LDGyMFaX9k3lVHqu/tsQCy2giMymbport4y4p77mYcXEMlDaHMzlHgOQyHRniWFA==",
       "optional": true
     },
     "@next/swc-win32-ia32-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-12.3.1.tgz",
-      "integrity": "sha512-Kny5JBehkTbKPmqulr5i+iKntO5YMP+bVM8Hf8UAmjSMVo3wehyLVc9IZkNmcbxi+vwETnQvJaT5ynYBkJ9dWA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.0.1.tgz",
+      "integrity": "sha512-Krr/qGN7OB35oZuvMAZKoXDt2IapynIWLh5A5rz6AODb7f/ZJqyAuZSK12vOa2zKdobS36Qm4IlxxBqn9c00MA==",
       "optional": true
     },
     "@next/swc-win32-x64-msvc": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-12.3.1.tgz",
-      "integrity": "sha512-W1ijvzzg+kPEX6LAc+50EYYSEo0FVu7dmTE+t+DM4iOLqgGHoW9uYSz9wCVdkXOEEMP9xhXfGpcSxsfDucyPkA==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.0.1.tgz",
+      "integrity": "sha512-t/0G33t/6VGWZUGCOT7rG42qqvf/x+MrFp1CU+8CN6PrjSSL57R5bqkXfubV9t4eCEnUxVP+5Hn3MoEXEebtEw==",
       "optional": true
     },
     "@nodelib/fs.scandir": {
@@ -42026,6 +42034,11 @@
         "string-width": "^4.2.0"
       }
     },
+    "client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
+    },
     "cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -43651,12 +43664,12 @@
       }
     },
     "eslint-config-next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-12.3.1.tgz",
-      "integrity": "sha512-EN/xwKPU6jz1G0Qi6Bd/BqMnHLyRAL0VsaQaWA7F3KkjAgZHi4f1uL1JKGWNxdQpHTW/sdGONBd0bzxUka/DJg==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-13.0.1.tgz",
+      "integrity": "sha512-/N9UpSwkbEMj5pIiB235p7QHaSW08ta/iKVaIHF44wufxr+PuJVLwg5LzlAaQbmCZCBpYvVttl3ZxTusP1g2sg==",
       "dev": true,
       "requires": {
-        "@next/eslint-plugin-next": "12.3.1",
+        "@next/eslint-plugin-next": "13.0.1",
         "@rushstack/eslint-patch": "^1.1.3",
         "@typescript-eslint/parser": "^5.21.0",
         "eslint-import-resolver-node": "^0.3.6",
@@ -49981,28 +49994,28 @@
       "dev": true
     },
     "next": {
-      "version": "12.3.1",
-      "resolved": "https://registry.npmjs.org/next/-/next-12.3.1.tgz",
-      "integrity": "sha512-l7bvmSeIwX5lp07WtIiP9u2ytZMv7jIeB8iacR28PuUEFG5j0HGAPnMqyG5kbZNBG2H7tRsrQ4HCjuMOPnANZw==",
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/next/-/next-13.0.1.tgz",
+      "integrity": "sha512-ErCNBPIeZMKFn6hX+ZBSlqZVgJIeitEqhGTuQUNmYXJ07/A71DZ7AJI8eyHYUdBb686LUpV1/oBdTq9RpzRVPg==",
       "requires": {
-        "@next/env": "12.3.1",
-        "@next/swc-android-arm-eabi": "12.3.1",
-        "@next/swc-android-arm64": "12.3.1",
-        "@next/swc-darwin-arm64": "12.3.1",
-        "@next/swc-darwin-x64": "12.3.1",
-        "@next/swc-freebsd-x64": "12.3.1",
-        "@next/swc-linux-arm-gnueabihf": "12.3.1",
-        "@next/swc-linux-arm64-gnu": "12.3.1",
-        "@next/swc-linux-arm64-musl": "12.3.1",
-        "@next/swc-linux-x64-gnu": "12.3.1",
-        "@next/swc-linux-x64-musl": "12.3.1",
-        "@next/swc-win32-arm64-msvc": "12.3.1",
-        "@next/swc-win32-ia32-msvc": "12.3.1",
-        "@next/swc-win32-x64-msvc": "12.3.1",
+        "@next/env": "13.0.1",
+        "@next/swc-android-arm-eabi": "13.0.1",
+        "@next/swc-android-arm64": "13.0.1",
+        "@next/swc-darwin-arm64": "13.0.1",
+        "@next/swc-darwin-x64": "13.0.1",
+        "@next/swc-freebsd-x64": "13.0.1",
+        "@next/swc-linux-arm-gnueabihf": "13.0.1",
+        "@next/swc-linux-arm64-gnu": "13.0.1",
+        "@next/swc-linux-arm64-musl": "13.0.1",
+        "@next/swc-linux-x64-gnu": "13.0.1",
+        "@next/swc-linux-x64-musl": "13.0.1",
+        "@next/swc-win32-arm64-msvc": "13.0.1",
+        "@next/swc-win32-ia32-msvc": "13.0.1",
+        "@next/swc-win32-x64-msvc": "13.0.1",
         "@swc/helpers": "0.4.11",
         "caniuse-lite": "^1.0.30001406",
         "postcss": "8.4.14",
-        "styled-jsx": "5.0.7",
+        "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
       },
       "dependencies": {
@@ -53467,10 +53480,12 @@
       }
     },
     "styled-jsx": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.0.7.tgz",
-      "integrity": "sha512-b3sUzamS086YLRuvnaDigdAewz1/EFYlHpYBP5mZovKEdQQOIIYq8lApylub3HHZ6xFjV051kkGU7cudJmrXEA==",
-      "requires": {}
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.0.tgz",
+      "integrity": "sha512-/iHaRJt9U7T+5tp6TRelLnqBqiaIT0HsO0+vgyj8hK2KUk7aejFqRrumqPUlAqDwAj8IbS/1hk3IhBAAK/FCUQ==",
+      "requires": {
+        "client-only": "0.0.1"
+      }
     },
     "supports-color": {
       "version": "5.5.0",

--- a/app/package.json
+++ b/app/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@uswds/uswds": "^3.1.0",
     "i18next": "^21.9.2",
-    "next": "^12.3.1",
+    "next": "^13.0.1",
     "next-i18next": "^12.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -46,7 +46,7 @@
     "@typescript-eslint/parser": "^5.39.0",
     "eslint": "^8.24.0",
     "eslint-config-nava": "^11.0.0",
-    "eslint-config-next": "^12.3.1",
+    "eslint-config-next": "^13.0.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-storybook": "^0.6.4",


### PR DESCRIPTION
## Ticket

Closes #65

## Context for reviewers

Next.js 13 introduced [pretty significant new functionality](https://nextjs.org/blog/next-13), but it's backwards compatible with the existing approach implemented in this repo, so should be safe to upgrade. Projects can adopt its new functionality as they want. We have a separate ticket for adopting the new functionality in this repo: #66

