### PR TITLE
Fix double-escaping in internationlized strings

### DIFF
--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -17,6 +17,9 @@ const i18n = {
 const i18next = {
   defaultNS: "common",
   fallbackLng: i18n.defaultLocale,
+  interpolation: {
+    escapeValue: false, // React already does escaping
+  },
 };
 
 /**


### PR DESCRIPTION
## Changes

- Disable i18next's escaping functionality in order to fix strings being double-escaped.

## Testing

With a string like: 

```
"status_upcoming": "Certification opens on {{date, datetime}}",
```

Before:

<img width="284" alt="CleanShot 2022-11-01 at 10 58 06@2x" src="https://user-images.githubusercontent.com/371943/199304592-e111d5b0-e4c5-4f55-bfa2-8ca9472e26b2.png">

After:

<img width="258" alt="CleanShot 2022-11-01 at 10 57 39@2x" src="https://user-images.githubusercontent.com/371943/199304510-a0927e65-c1d9-4549-ad57-4f709c1673ed.png">
