### PR TITLE
Support Storybook deploys to GitHub Pages

### DIFF
--- a/app/.storybook/i18next.js
+++ b/app/.storybook/i18next.js
@@ -11,6 +11,11 @@ i18next
   .use(initReactI18next)
   .use(LanguageDetector)
   .use(Backend)
-  .init(i18nConfig);
+  .init({
+    ...i18nConfig,
+    backend: {
+      loadPath: `${process.env.BASE_PATH ?? ""}/locales/{{lng}}/{{ns}}.json`,
+    },
+  });
 
 export default i18next;

--- a/app/README.md
+++ b/app/README.md
@@ -121,9 +121,10 @@ It's recommended that developers configure their code editor to auto run these t
    }
    ```
 
-   </details>
+</details>
 
 ## Other topics
 
+- [Deployment](../docs/deployment.md)
 - [Internationalization](../docs/internationalization.md)
 - Refer to the [architecture decision records](../docs/decisions) for more context on technical decisions.

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -51,6 +51,7 @@
         "sass": "^1.55.0",
         "sass-loader": "^13.0.2",
         "storybook-react-i18next": "^1.1.2",
+        "string-replace-loader": "^3.1.0",
         "style-loader": "^3.3.1",
         "typescript": "^4.8.4"
       }
@@ -29035,6 +29036,19 @@
         "node": ">=10"
       }
     },
+    "node_modules/string-replace-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.1.0.tgz",
+      "integrity": "sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==",
+      "dev": true,
+      "dependencies": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -53350,6 +53364,16 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
+      }
+    },
+    "string-replace-loader": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.1.0.tgz",
+      "integrity": "sha512-5AOMUZeX5HE/ylKDnEa/KKBqvlnFmRZudSOjVJHxhoJg9QYTwl1rECx7SLR8BBH7tfxb4Rp7EM2XVfQFxIhsbQ==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^2.0.0",
+        "schema-utils": "^3.0.0"
       }
     },
     "string-width": {

--- a/app/package.json
+++ b/app/package.json
@@ -61,6 +61,7 @@
     "sass": "^1.55.0",
     "sass-loader": "^13.0.2",
     "storybook-react-i18next": "^1.1.2",
+    "string-replace-loader": "^3.1.0",
     "style-loader": "^3.3.1",
     "typescript": "^4.8.4"
   }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,90 @@
+# Deployments
+
+## Next.js app
+
+The Next.js app can be deployed as a static HTML export or as a Node.js server, depending on your needs. The [Next.js deployment documentation](https://nextjs.org/docs/deployment) provides more information on how to deploy your application.
+
+## Storybook
+
+Storybook can be deployed as a static HTML export. The [Storybook deployment documentation](https://storybook.js.org/docs/react/sharing/publish-storybook) provides more information on deployment options.
+
+### GitHub Pages
+
+[GitHub Pages](https://pages.github.com/) may be a good option for hosting Storybook if you only need one environment to represent the latest state of your main branch.
+
+**Steps to setup GitHub Pages**
+
+1. Add a workflow to automatically deploy Storybook: `.github/workflows/deploy-storybook.yml` (see example below)
+1. Enable the "GitHub Actions" source in your rep settings (`Settings > Pages > Source`)
+1. Trigger the workflow from the Actions tab or by pushing a commit to your main branch
+
+---
+
+<details>
+  <summary>View GitHub workflow</summary>
+
+```yaml
+name: Deploy Storybook
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow access to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Cancel any older in-progress runs of this workflow
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16"
+          cache: npm
+          cache-dependency-path: ./app/package-lock.json
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+        id: pages_config
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./app
+      - name: Build
+        run: BASE_PATH=${{ steps.pages_config.outputs.base_path }} npm run storybook-build
+        working-directory: ./app
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: ./app/storybook-static
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.hosting.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: hosting
+        uses: actions/deploy-pages@v1
+```
+
+</details>
+
+---
+
+If your GitHub repo is public and you're using the default domain, Storybook will be hosted at a subdirectory: `https://<repo-owner-username>.github.io/<repo-name>/`. A `BASE_PATH` environment variable is available to your code so that any relative paths can be properly prefixed with the subdirectory where your Storybook is hosted. The Storybook configuration is already setup to use this environment variable.


### PR DESCRIPTION
## Ticket

#88 

## Changes

- Add `BASE_PATH` environment variable to Storybook to support hosting the site on GitHub Pages
- Add documentation on deploying both Next.js and Storybook, along with an example GitHub Workflow for deploying Storybook to GitHub Pages

## Context for reviewers

GitHub's default url for public Pages sites is `{username}.github.io/{repo}`, which means paths in the code can't assume the site is hosted at the root of a domain, and it needs the ability to prefix any relative paths with the subdirectory where the site is hosted.

## Testing

We utilize this approach on DOL ARPA and the GitHub Workflow snippet is copied from there.