### PR TITLE
Deploy template to platform-test-nextjs on merges

### DIFF
--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -1,0 +1,40 @@
+name: Template Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+# Only allow one workflow at a time to prevent race conditions when pushing changes to the project repo
+concurrency: template-only-cd
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout template repo
+        uses: actions/checkout@v3
+        with:
+          path: template-application-nextjs
+      - name: Checkout project repo
+        uses: actions/checkout@v3
+        with:
+          path: project-repo
+          repository: navapbc/platform-test-nextjs
+          token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+
+      - name: Update application template
+        working-directory: project-repo
+        run: ../template-application-nextjs/template-only-bin/update-template.sh
+
+      - name: Push changes to project repo
+        working-directory: project-repo
+        run: |
+          git config user.name nava-platform-bot
+          git config user.email platform-admins@navapbc.com
+          git add --all
+          # Commit changes (if no changes then no-op)
+          git diff-index --quiet HEAD || git commit -m "Template application deploy #${{ github.run_id }}"
+          git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: template-application-nextjs
+          ref: lorenyu/templatecd
       - name: Checkout project repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -2,8 +2,6 @@ name: Template Deploy
 
 on:
   push:
-    branches:
-      - main
   workflow_dispatch:
 
 # Only allow one workflow at a time to prevent race conditions when pushing changes to the project repo

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -18,3 +18,24 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: template-application-nextjs
+          ref: lorenyu/templatecd
+      - name: Checkout project repo
+        uses: actions/checkout@v3
+        with:
+          path: project-repo
+          repository: navapbc/platform-test-nextjs
+          token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
+
+      - name: Update application template
+        working-directory: project-repo
+        run: ../template-application-nextjs/template-only-bin/update-template.sh
+
+      - name: Push changes to project repo
+        working-directory: project-repo
+        run: |
+          git config user.name nava-platform-bot
+          git config user.email platform-admins@navapbc.com
+          git add --all
+          # Commit changes (if no changes then no-op)
+          git diff-index --quiet HEAD || git commit -m "Template application deploy #${{ github.run_id }}"
+          git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -18,24 +18,3 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: template-application-nextjs
-          ref: lorenyu/templatecd
-      - name: Checkout project repo
-        uses: actions/checkout@v3
-        with:
-          path: project-repo
-          repository: navapbc/platform-test-nextjs
-          token: ${{ secrets.PLATFORM_BOT_GITHUB_TOKEN }}
-
-      - name: Update application template
-        working-directory: project-repo
-        run: ../template-application-nextjs/template-only-bin/update-template.sh
-
-      - name: Push changes to project repo
-        working-directory: project-repo
-        run: |
-          git config user.name nava-platform-bot
-          git config user.email platform-admins@navapbc.com
-          git add --all
-          # Commit changes (if no changes then no-op)
-          git diff-index --quiet HEAD || git commit -m "Template application deploy #${{ github.run_id }}"
-          git push

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           path: template-application-nextjs
-          ref: lorenyu/templatecd
       - name: Checkout project repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/template-only-cd.yml
+++ b/.github/workflows/template-only-cd.yml
@@ -2,6 +2,8 @@ name: Template Deploy
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 # Only allow one workflow at a time to prevent race conditions when pushing changes to the project repo

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See [`navapbc/platform`](https://github.com/navapbc/platform) for other template
 To get started using the template application on your project, run the following command to execute the [install script](https://github.com/navapbc/template-application-nextjs/tree/main/template-only-bin/install-template.sh), which clones the template repository, copies the template files to your repository, and then cleans up the template repository:
 
 ```bash
-curl https://raw.githubusercontent.com/navapbc/template-application-nextjs/main/template-only-bin/install-template.sh | bash -s
+curl https://raw.githubusercontent.com/navapbc/template-application-nextjs/main/template-only-bin/download-and-install-template.sh | bash -s
 ```
 
 Now you're ready to set up the various pieces of your infrastructure.

--- a/template-only-bin/download-and-install-template.sh
+++ b/template-only-bin/download-and-install-template.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "Fetch latest version of template-application-nextjs"
+git clone --single-branch --branch main --depth 1 git@github.com:navapbc/template-application-nextjs.git
+
+echo "Install template"
+./template-application-nextjs/template-only-bin/install-template.sh
+
+echo "Clean up template-application-nextjs folder"
+rm -fr template-application-nextjs

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
+#
+# This script installs template-application-nextjs to your project. Run
+# This script from your project's root directory.
 set -euo pipefail
 
-echo "Fetch latest version of template-application-nextjs"
-git clone --single-branch --branch main --depth 1 git@github.com:navapbc/template-application-nextjs.git
+CUR_DIR=$(pwd)
+SCRIPT_DIR=$(dirname $0)
+TEMPLATE_DIR="$SCRIPT_DIR/.."
 
 echo "Copy files from template-application-nextjs"
-cd template-application-nextjs
+cd $TEMPLATE_DIR
 cp -r \
   .github \
   docs \
   app \
   docker-compose.yml \
   renovate.json \
-  ..
-cd ..
+  $CUR_DIR
+cd -
 
-echo "Clean up template-application-nextjs folder"
-rm -fr template-application-nextjs
+echo "Remove files relevant only to template development"
+rm .github/workflows/template-only-*

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# This script updates template-infra in your project. Run
+# This script from your project's root directory.
+set -euo pipefail
+
+SCRIPT_DIR=$(dirname $0)
+
+echo "Install template"
+$SCRIPT_DIR/install-template.sh
+
+# Restore project files with project-specific configuration that was defined as part of project setup.
+# This includes the terraform backend configuration blocks and the project-config module
+# Also restore project files that had lines that were commented out in the template, such as Makefile
+# and cd.yml workflow
+# Updates in any of these files need to be manually applied to the projects
+echo "Restore modified project files"
+git checkout HEAD -- \
+  .github/workflows/cd-storybook.yml

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -15,5 +15,5 @@ $SCRIPT_DIR/install-template.sh
 # and cd.yml workflow
 # Updates in any of these files need to be manually applied to the projects
 echo "Restore modified project files"
-# git checkout HEAD -- \
-#   .github/workflows/cd-storybook.yml
+git checkout HEAD -- \
+  .github/workflows/cd-storybook.yml

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -15,5 +15,5 @@ $SCRIPT_DIR/install-template.sh
 # and cd.yml workflow
 # Updates in any of these files need to be manually applied to the projects
 echo "Restore modified project files"
-git checkout HEAD -- \
-  .github/workflows/cd-storybook.yml
+# git checkout HEAD -- \
+#   .github/workflows/cd-storybook.yml


### PR DESCRIPTION
## Ticket

Resolves #94 

## Changes
* Add template-only-cd which deploys the application template to the platform-test-nextjs test project repo after merges
* Rename install-template.sh to download-and-install-template.sh and split out the cp commands into an install-template.sh script
* Add an update-template.sh script that resets files the project will have modified from the template

## Context for reviewers
Context from ticket:
In order to continuously integrate template-infra and template-application-nextjs, we should deploy changes to template-application-nextjs to the platform-test-nextjs repo, which is the repo we're using to test the integration of the two templates.

We are already doing this with template-infra in https://github.com/navapbc/template-infra/issues/196, this is the corresponding ticket for template-application-nextjs

## Testing
* Manually triggered [the deploy workflow run](https://github.com/navapbc/template-application-nextjs/actions/runs/3597857685) from this branch, which created [this commit on platform-test-nextjs](https://github.com/navapbc/platform-test-nextjs/commit/56739c32ab0a27adf8ffc6ba68432bf82d1d1e0e)
* Enabled the cd-storybook.yml workflow in platform-test-nextjs in [this commit](https://github.com/navapbc/platform-test-nextjs/commit/e398390104ca3d87f104d196bbcb6c77464d58ed), which triggered [this storybook deploy run](https://github.com/navapbc/platform-test-nextjs/actions/runs/3597902740), and now storybook is deployed at https://navapbc.github.io/platform-test-nextjs
* [A second trigger of the template deploy](https://github.com/navapbc/template-application-nextjs/actions/runs/3597904076/jobs/6060148391) was a no-op since there were no new changes to push