### PR TITLE
Update storybook config to display USWDS images when deploying to a subdir

### DIFF
--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -52,7 +52,7 @@ const config = {
             // It handles relative urls, whether they are quoted or not.
             search: /url\(("?)\//g,
             replace(match, p1, offset, string) {
-              return `url(${p1}${BASE_PATH}/`
+              return `url(${p1}${BASE_PATH}/`;
             },
           },
         },

--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -49,8 +49,11 @@ const config = {
           options: {
             // Support deploying Storybook to a subdirectory (like GitHub Pages).
             // This adds the BASE_PATH to the beginning of all relative URLs in the CSS.
-            search: /url\(\//g,
-            replace: `url(${BASE_PATH}/`,
+            // It handles relative urls, whether they are quoted or not.
+            search: /url\(("?)\//g,
+            replace(match, p1, offset, string) {
+              return `url(${p1}${BASE_PATH}/`
+            },
           },
         },
         {


### PR DESCRIPTION
## Ticket

https://github.com/navapbc/template-application-nextjs/issues/97

## Changes
> What was added, updated, or removed in this PR.

- Update regex for storybook string replacement to support deploying to a subdirectory

## Context for reviewers
> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. Explain how the changes were verified.

I deployed https://github.com/navapbc/template-application-nextjs/pull/89 to WIC MT Demo Project in order to get our storybook deployed using github pages. I found an issue where the images weren't displaying properly and made a PR for it: https://github.com/navapbc/wic-mt-demo-project-eligibility-screener/pull/168 This PR is a port of that one.

See also Slack discussion: https://nava.slack.com/archives/C03G1SWD9H7/p1669820652173809

I inspected the [generated github action artifact](https://github.com/navapbc/template-application-nextjs/actions/runs/3633298101) and confirmed that we are currently correctly prepending the BASE_PATH to any relative paths in storybook that begin with url(/. However, USWDS also uses this syntax url("/ and our regex doesn't catch that.

## Testing
> Screenshots, GIF demos, code examples or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.

1. Go to [this github action run](), which builds storybook for this branch and deploys it to github pages
2. Download the generated artifact
3. Unzip the artifact
4. Grep the unzipped files and confirm that `"/uswds/img` does not appear and that `"template-application-nextjs/uswds/img` does appear
