### PR TITLE
Fix container vulnerabilities

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -2,10 +2,6 @@
 # https://github.com/anchore/grype#specifying-matches-to-ignore
 # More info can be found in the docs/infra/vulnerability-management.md file
 
-# List of vulnerabilities to ignore for the anchore scan
-# https://github.com/anchore/grype#specifying-matches-to-ignore
-# More info can be found in the docs/infra/vulnerability-management.md file
-
 # Please add safelists in the following format to make it easier when checking
 # Package/module name: URL to vulnerability for checking updates
 #  Versions:     URL to the version history

--- a/.grype.yml
+++ b/.grype.yml
@@ -1,0 +1,49 @@
+# List of vulnerabilities to ignore for the anchore scan
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+# More info can be found in the docs/infra/vulnerability-management.md file
+
+# List of vulnerabilities to ignore for the anchore scan
+# https://github.com/anchore/grype#specifying-matches-to-ignore
+# More info can be found in the docs/infra/vulnerability-management.md file
+
+# Please add safelists in the following format to make it easier when checking
+# Package/module name: URL to vulnerability for checking updates
+#  Versions:     URL to the version history
+#  Dependencies: Name of any other packages or modules that are dependent on this version
+#                 Link to the dependencies for ease of checking for updates
+#  Issue:         Why there is a finding and why this is here or not been removed
+#  Last checked:  Date last checked in scans
+# - vulnerability: The-CVE-or-vuln-id # Remove comment at start of line
+
+ignore:
+  # These settings ignore any findings that fall into these categories
+  - fix-state: not-fixed
+  - fix-state: wont-fix
+  - fix-state: unknown
+
+  # glob-parent before 5.1.2 vulnerable to Regular Expression Denial of Service in enclosure regex
+  # https://github.com/advisories/GHSA-ww39-953v-wcq6
+  # High severity
+  # Ignoring since this is only a dependency of dev tools: storybook (for storybook docs site),
+  # eslint (for Linting in CI), and sass (for compiling CSS during CI build phase)
+  - vulnerability: GHSA-ww39-953v-wcq6
+
+  # Regular Expression Denial of Service in trim
+  # https://github.com/advisories/GHSA-w5p7-h5w8-2hfq
+  # High severity
+  # Ignoring since this is only used in storybook which is a dev tool
+  - vulnerability: GHSA-w5p7-h5w8-2hfq
+
+  #####################
+  ## False positives ##
+  #####################
+
+  # http-cache-semantics vulnerable to Regular Expression Denial of Service
+  # https://github.com/advisories/GHSA-rc47-6667-2j5j
+  # http-cache-semantics does not exist as a dependency in this app
+  - vulnerability: GHSA-rc47-6667-2j5j
+
+  # Uncontrolled Resource Consumption in trim-newlines
+  # https://github.com/advisories/GHSA-7p7h-4mm5-852v
+  # trim-newlines does not exist as a dependency in this app
+  - vulnerability: GHSA-7p7h-4mm5-852v

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -4,15 +4,28 @@ FROM node:16-alpine
 # Keep container packages up-to-date.
 # -U runs both apk update and apk upgrade.
 RUN apk -U upgrade
-# Copy just the package data to the working directory.
-COPY package-lock.json /srv
-COPY package.json /srv
-WORKDIR /srv
-# Copy all the remaining application files (ignoring files in .dockerignore) to the working directory.
-COPY . /srv
+
+
+# setup user stuff
+ARG RUN_UID
+ARG RUN_USER
+
+# The following logic creates the RUN_USER home directory and the directory where
+# we will be storing the application in the image. This runs when the user is not root
+RUN : "${RUN_USER:?RUN_USER and RUN_UID need to be set and non-empty.}" && \
+  [ "${RUN_USER}" = "root" ] || \
+  (addgroup -S "${RUN_USER}" && adduser -S -G "${RUN_USER}" -h "/home/${RUN_USER}" -u ${RUN_UID} "${RUN_USER}" \
+  && mkdir /app \
+  && chown -R "${RUN_USER}:${RUN_USER}" "/home/${RUN_USER}" /app)
+
+USER ${RUN_USER}
+WORKDIR /app
+
+# Copy all the application files (ignoring files in .dockerignore) to the working directory.
+COPY --chown="${RUN_USER}:${RUN_USER}" . /app
 # Install application dependencies.
 RUN npm ci
 # Build the application.
 RUN npm run build
 # Run the application.
-CMD npm run start
+CMD ["npm", "run", "start"]

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,8 +1,31 @@
 .PHONY : \
 	release-build
 
+# Docker user configuration
+# This logic is to avoid issues with permissions and mounting local volumes,
+# which should be owned by the same UID for Linux distros. Mac OS can use root,
+# but it is best practice to run things as with least permission where possible
+
+# Can be set by adding user=<username> and/ or uid=<id> after the make command
+# If variables are not set explicitly: try looking up values from current
+# environment, otherwise fixed defaults.
+# uid= defaults to 0 if user= set (which makes sense if user=root, otherwise you
+# probably want to set uid as well).
+ifeq ($(user),)
+RUN_USER ?= $(or $(strip $(USER)),nodummy)
+RUN_UID ?= $(or $(strip $(shell id -u)),4000)
+else
+RUN_USER = $(user)
+RUN_UID = $(or $(strip $(uid)),0)
+endif
+
+export RUN_USER
+export RUN_UID
+
 release-build:
 	docker buildx build \
 		--platform=linux/amd64 \
+		--build-arg RUN_USER=$(RUN_USER) \
+		--build-arg RUN_UID=$(RUN_UID) \
 		$(OPTS) \
 		.


### PR DESCRIPTION
## Ticket

N/A

## Changes
* Configure grype to ignore vulnerabilities in dev dependencies
* Configure grype to ignore false positives (vulnerabilities in packages that aren't in the app)
* Use non-root user in Docker container (addresses issue discovered by scanners)
* Use JSON syntax for Docker start CMD (addresses issue discovered by dockle scanner)

## Context for reviewers
This PR https://github.com/navapbc/template-infra/pull/203 introduced a new CI check that scans containers for vulnerabilities. The template-application-nextjs Docker container currently fails some of those scans:
- hadolint scan warning to use JSON notation for docker CMD https://github.com/navapbc/platform-test-nextjs/actions/runs/4318667731/jobs/7537233036
- anchore scan for package vulnerabilities https://github.com/navapbc/platform-test-nextjs/actions/runs/4325545437/jobs/7551843431
- dockle scan showing docker container using root user https://github.com/navapbc/platform-test-nextjs/actions/runs/4325545437/jobs/7551843682

This PR fixes those issues.

Note: The package scan issues were ignored with a config file change since they don't affect the prod application.

## Testing
I tested the changes in the integration test repo, platform-test-nextjs, in this PR: https://github.com/navapbc/platform-test-nextjs/pull/56