### PR TITLE
Copy scanner configs on install

### DIFF
--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -11,10 +11,14 @@ TEMPLATE_DIR="$SCRIPT_DIR/.."
 echo "Copy files from template-application-nextjs"
 cd $TEMPLATE_DIR
 cp -r \
+  .dockleconfig \
   .github \
-  docs \
+  .grype.yml \
+  .hadolint.yaml \
+  .trivyignore \
   app \
   docker-compose.yml \
+  docs \
   renovate.json \
   $CUR_DIR
 cd -

--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -11,11 +11,8 @@ TEMPLATE_DIR="$SCRIPT_DIR/.."
 echo "Copy files from template-application-nextjs"
 cd $TEMPLATE_DIR
 cp -r \
-  .dockleconfig \
   .github \
   .grype.yml \
-  .hadolint.yaml \
-  .trivyignore \
   app \
   docker-compose.yml \
   docs \


### PR DESCRIPTION
## Ticket

n/a

## Changes
see title

## Context for reviewers
PR https://github.com/navapbc/template-application-nextjs/pull/124 added scanner configs to the template but we didn't add it to the template installation script, so [one of the vulnerability scans is still failing](https://github.com/navapbc/platform-test-nextjs/actions/runs/4345788954)

## Testing
Didn't do testing but I think this is a simple and low risk enough change