### PR TITLE
Recategorize trim-newlines as dev tool not false positive

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -30,6 +30,11 @@ ignore:
   # Ignoring since this is only used in storybook which is a dev tool
   - vulnerability: GHSA-w5p7-h5w8-2hfq
 
+  # Uncontrolled Resource Consumption in trim-newlines
+  # https://github.com/advisories/GHSA-7p7h-4mm5-852v
+  # Ignoring since this is only used in storybook which is a dev tool
+  - vulnerability: GHSA-7p7h-4mm5-852v
+
   #####################
   ## False positives ##
   #####################
@@ -38,8 +43,3 @@ ignore:
   # https://github.com/advisories/GHSA-rc47-6667-2j5j
   # http-cache-semantics does not exist as a dependency in this app
   - vulnerability: GHSA-rc47-6667-2j5j
-
-  # Uncontrolled Resource Consumption in trim-newlines
-  # https://github.com/advisories/GHSA-7p7h-4mm5-852v
-  # trim-newlines does not exist as a dependency in this app
-  - vulnerability: GHSA-7p7h-4mm5-852v


### PR DESCRIPTION
## Ticket

{LINK TO TICKET}

## Changes
see title

## Context for reviewers
Sorry my mistake, this actually is a real dev dependency

```
➜  app git:(lorenyu/recategorizetrimnewlines) npm ls trim-newlines
app@0.1.0 /Users/lorenyu/Projects/platform/template-application-nextjs/app
└─┬ @storybook/react@6.5.12
  └─┬ @storybook/core@6.5.12
    └─┬ @storybook/core-server@6.5.12
      └─┬ x-default-browser@0.4.0
        └─┬ default-browser-id@1.0.4
          └─┬ meow@3.7.0
            └── trim-newlines@1.0.0
```

## Testing
none, no functional change