### PR TITLE
Make it easier to configure Next.js’s basePath config without breaking static assets

### DIFF
--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -4,7 +4,7 @@
  * @see https://storybook.js.org/docs/configurations/default-config/
  */
 // @ts-check
-const nextConfig = require("../next.config");
+const sassOptions = require("../scripts/sassOptions");
 
 const BASE_PATH = process.env.BASE_PATH ?? "";
 
@@ -45,18 +45,6 @@ const config = {
         "style-loader",
         { loader: "css-loader", options: { url: false } }, // this mirrors next.js behavior
         {
-          loader: "string-replace-loader",
-          options: {
-            // Support deploying Storybook to a subdirectory (like GitHub Pages).
-            // This adds the BASE_PATH to the beginning of all relative URLs in the CSS.
-            // It handles relative urls, whether they are quoted or not.
-            search: /url\(("?)\//g,
-            replace(match, p1, offset, string) {
-              return `url(${p1}${BASE_PATH}/`;
-            },
-          },
-        },
-        {
           /**
            * Next.js sets this automatically for us, but we need to manually set it here for Storybook.
            * The main thing this enables is autoprefixer, so any experimental CSS properties work.
@@ -71,7 +59,7 @@ const config = {
         {
           loader: "sass-loader",
           options: {
-            sassOptions: nextConfig.sassOptions,
+            sassOptions: sassOptions(BASE_PATH),
           },
         },
       ],

--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -6,7 +6,9 @@
 // @ts-check
 const sassOptions = require("../scripts/sassOptions");
 
+// Support deploying to a subdirectory, such as GitHub Pages.
 const BASE_PATH = process.env.BASE_PATH ?? "";
+const storybookSassOptions = sassOptions(BASE_PATH);
 
 /**
  * @type {import("@storybook/core-common").StorybookConfig}
@@ -59,7 +61,7 @@ const config = {
         {
           loader: "sass-loader",
           options: {
-            sassOptions: sassOptions(BASE_PATH),
+            sassOptions: storybookSassOptions,
           },
         },
       ],

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -9,13 +9,14 @@ const sassOptions = require("./scripts/sassOptions");
  * @see https://nextjs.org/docs/api-reference/next.config.js/basepath
  */
 const basePath = "";
+const appSassOptions = sassOptions(basePath);
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   basePath,
   i18n,
   reactStrictMode: true,
-  sassOptions: sassOptions(basePath),
+  sassOptions: appSassOptions,
 };
 
 module.exports = nextConfig;

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -1,16 +1,21 @@
-/** @type {import('next').NextConfig} */
-
+// @ts-check
 const { i18n } = require("./next-i18next.config");
+const sassOptions = require("./scripts/sassOptions");
 
+/**
+ * Configure the base path for the app. Useful if you're deploying to a subdirectory (like GitHub Pages).
+ * If this isn't an empty string, you'll need to set the base path anywhere you use relative paths,
+ * like in `<a>`, `<img>`, or `<Image>` tags. Next.js handles this for you automatically in `<Link>` tags.
+ * @see https://nextjs.org/docs/api-reference/next.config.js/basepath
+ */
+const basePath = "/test";
+
+/** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath,
   i18n,
   reactStrictMode: true,
-  sassOptions: {
-    includePaths: [
-      "./node_modules/@uswds",
-      "./node_modules/@uswds/uswds/packages",
-    ],
-  },
+  sassOptions: sassOptions(basePath),
 };
 
 module.exports = nextConfig;

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -4,11 +4,12 @@ const sassOptions = require("./scripts/sassOptions");
 
 /**
  * Configure the base path for the app. Useful if you're deploying to a subdirectory (like GitHub Pages).
- * If this isn't an empty string, you'll need to set the base path anywhere you use relative paths,
- * like in `<a>`, `<img>`, or `<Image>` tags. Next.js handles this for you automatically in `<Link>` tags.
+ * If this is defined, you'll need to set the base path anywhere you use relative paths, like in
+ * `<a>`, `<img>`, or `<Image>` tags. Next.js handles this for you automatically in `<Link>` tags.
  * @see https://nextjs.org/docs/api-reference/next.config.js/basepath
+ * @example "/test" results in "localhost:3000/test" as the index page for the app
  */
-const basePath = "";
+const basePath = undefined;
 const appSassOptions = sassOptions(basePath);
 
 /** @type {import('next').NextConfig} */

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -8,7 +8,7 @@ const sassOptions = require("./scripts/sassOptions");
  * like in `<a>`, `<img>`, or `<Image>` tags. Next.js handles this for you automatically in `<Link>` tags.
  * @see https://nextjs.org/docs/api-reference/next.config.js/basepath
  */
-const basePath = "/test";
+const basePath = "";
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/app/package.json
+++ b/app/package.json
@@ -62,7 +62,6 @@
     "sass": "^1.55.0",
     "sass-loader": "^13.0.2",
     "storybook-react-i18next": "^1.1.2",
-    "string-replace-loader": "^3.1.0",
     "style-loader": "^3.3.1",
     "typescript": "^4.8.4"
   }

--- a/app/scripts/sassOptions.js
+++ b/app/scripts/sassOptions.js
@@ -1,0 +1,22 @@
+// @ts-check
+const sass = require("sass");
+
+/**
+ * Configure Sass to load USWDS assets, and expose a Sass function for setting the
+ * correct relative path to image or font assets, when the site is hosted from a subdirectory.
+ */
+function sassOptions(basePath = "") {
+  return {
+    includePaths: [
+      "./node_modules/@uswds",
+      "./node_modules/@uswds/uswds/packages",
+    ],
+    functions: {
+      "add-base-path($path)": (path) => {
+        return new sass.SassString(`${basePath}${path.getValue()}`);
+      },
+    },
+  };
+}
+
+module.exports = sassOptions;

--- a/app/styles/_uswds-theme.scss
+++ b/app/styles/_uswds-theme.scss
@@ -13,6 +13,6 @@ in the form $setting: value,
 
   // Specify USWDS font and image paths.
   // Same paths are successfully used for both Next.js and Storybook.
-  $theme-font-path: "/uswds/fonts",
-  $theme-image-path: "/uswds/img"
+  $theme-font-path: add-base-path("/uswds/fonts"),
+  $theme-image-path: add-base-path("/uswds/img")
 );


### PR DESCRIPTION
## Changes

- Expose a new `add-base-path` function to our Sass files, to support hosting the site at a subdirectory.
- Preconfigure Next.js so that the relative paths in our Sass files output the correct path when Next.js's `basePath` property is configured.

## Context for reviewers

Setting `basePath` to `/test` results in the site's index becoming `localhost:3000/test`. Therefore any relative link should be relative to `/test` (e.g. `/test/img/foo.png`).

## Testing

Temporarily set the `basePath` to `/test` and confirmed the fonts still load:

<img width="734" alt="CleanShot 2023-03-15 at 15 59 15@2x" src="https://user-images.githubusercontent.com/371943/225462244-4a714253-6910-4cc6-9ee9-796b0f77aefb.png">
