### PR TITLE
Swap plugins used for sorting imports

### DIFF
--- a/app/.prettierrc.js
+++ b/app/.prettierrc.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+/** @type {import("@ianvs/prettier-plugin-sort-imports").PrettierConfig} */
+module.exports = {
+  /**
+   * Sort imports so that the order is roughly:
+   * - Built-in Node modules (`import ... from "fs"`)
+   * - Third-party modules (`import ... from "lodash"`)
+   * - Third-party modules that often export React components or hooks
+   * - Local components
+   * - All other files
+   * @see https://github.com/IanVS/prettier-plugin-sort-imports
+   */
+  importOrder: [
+    "<BUILTIN_MODULES>",
+    "<THIRD_PARTY_MODULES>",
+    "", // blank line
+    "i18next",
+    "^next[/-](.*)$",
+    "^react$",
+    "uswds",
+    "", // blank line
+    "^(src/)?components/(.*)$",
+    "^[./]",
+  ],
+  importOrderTypeScriptVersion: "5.0.0",
+};

--- a/app/.prettierrc.json
+++ b/app/.prettierrc.json
@@ -1,5 +1,0 @@
-{
-  "importOrder": ["^components/(.*)$", "^[./]"],
-  "importOrderSeparation": true,
-  "importOrderSortSpecifiers": true
-}

--- a/app/.storybook/i18next.js
+++ b/app/.storybook/i18next.js
@@ -1,11 +1,10 @@
 // Configure i18next for Storybook
 // See https://storybook.js.org/addons/storybook-react-i18next
+import i18nConfig from "../next-i18next.config";
 import i18next from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import Backend from "i18next-http-backend";
 import { initReactI18next } from "react-i18next";
-
-import i18nConfig from "../next-i18next.config";
 
 i18next
   .use(initReactI18next)

--- a/app/.storybook/preview.js
+++ b/app/.storybook/preview.js
@@ -1,7 +1,9 @@
 // @ts-check
 import i18nConfig from "../next-i18next.config";
+
 // Apply global styling to our stories
 import "../styles/styles.scss";
+
 // Import i18next config.
 import i18n from "./i18next.js";
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -19,6 +19,7 @@
         "react-i18next": "^13.0.0"
       },
       "devDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
         "@storybook/addon-essentials": "^7.0.23",
         "@storybook/nextjs": "^7.0.23",
         "@storybook/react": "^7.0.23",
@@ -26,7 +27,6 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
-        "@trivago/prettier-plugin-sort-imports": "^4.1.1",
         "@types/jest-axe": "^3.5.5",
         "@types/node": "^18.15.3",
         "@types/react": "^18.0.28",
@@ -3596,6 +3596,62 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@ianvs/prettier-plugin-sort-imports": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.2.tgz",
+      "integrity": "sha512-VnsTzyb9aSWpc3v6HvZKD6eolZRvofIYjhda+6IbW1GYwr2byWqK0KhLPbYNkit9MAgShad5bhZ1hgBn867A1A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.21.8",
+        "@babel/generator": "^7.21.5",
+        "@babel/parser": "^7.21.8",
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5",
+        "semver": "^7.5.0"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": ">=3.0.0",
+        "prettier": "2.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/semver": {
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@ianvs/prettier-plugin-sort-imports/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -7011,86 +7067,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/@trivago/prettier-plugin-sort-imports": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz",
-      "integrity": "sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/generator": "7.17.7",
-        "@babel/parser": "^7.20.5",
-        "@babel/traverse": "7.17.3",
-        "@babel/types": "7.17.0",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "^4.17.21"
-      },
-      "peerDependencies": {
-        "@vue/compiler-sfc": "3.x",
-        "prettier": "2.x"
-      },
-      "peerDependenciesMeta": {
-        "@vue/compiler-sfc": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.17.0",
-        "jsesc": "^2.5.1",
-        "source-map": "^0.5.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
-      "version": "7.17.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.3",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.3",
-        "@babel/types": "^7.17.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
-      "version": "7.17.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@trussworks/react-uswds": {
@@ -14692,12 +14668,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/javascript-natural-sort": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
-      "dev": true
     },
     "node_modules/jest": {
       "version": "29.5.0",
@@ -25045,6 +25015,46 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "@ianvs/prettier-plugin-sort-imports": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ianvs/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.2.tgz",
+      "integrity": "sha512-VnsTzyb9aSWpc3v6HvZKD6eolZRvofIYjhda+6IbW1GYwr2byWqK0KhLPbYNkit9MAgShad5bhZ1hgBn867A1A==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.21.8",
+        "@babel/generator": "^7.21.5",
+        "@babel/parser": "^7.21.8",
+        "@babel/traverse": "^7.21.5",
+        "@babel/types": "^7.21.5",
+        "semver": "^7.5.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.5.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
+          "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -27479,67 +27489,6 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
-    },
-    "@trivago/prettier-plugin-sort-imports": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.1.1.tgz",
-      "integrity": "sha512-dQ2r2uzNr1x6pJsuh/8x0IRA3CBUB+pWEW3J/7N98axqt7SQSm+2fy0FLNXvXGg77xEDC7KHxJlHfLYyi7PDcw==",
-      "dev": true,
-      "requires": {
-        "@babel/generator": "7.17.7",
-        "@babel/parser": "^7.20.5",
-        "@babel/traverse": "7.17.3",
-        "@babel/types": "7.17.0",
-        "javascript-natural-sort": "0.7.1",
-        "lodash": "^4.17.21"
-      },
-      "dependencies": {
-        "@babel/generator": {
-          "version": "7.17.7",
-          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
-          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.17.0",
-            "jsesc": "^2.5.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/traverse": {
-          "version": "7.17.3",
-          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
-          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.16.7",
-            "@babel/generator": "^7.17.3",
-            "@babel/helper-environment-visitor": "^7.16.7",
-            "@babel/helper-function-name": "^7.16.7",
-            "@babel/helper-hoist-variables": "^7.16.7",
-            "@babel/helper-split-export-declaration": "^7.16.7",
-            "@babel/parser": "^7.17.3",
-            "@babel/types": "^7.17.0",
-            "debug": "^4.1.0",
-            "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.17.0",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
-          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.16.7",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-          "dev": true
-        }
-      }
     },
     "@trussworks/react-uswds": {
       "version": "4.2.1",
@@ -33322,12 +33271,6 @@
           }
         }
       }
-    },
-    "javascript-natural-sort": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
-      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
-      "dev": true
     },
     "jest": {
       "version": "29.5.0",

--- a/app/package.json
+++ b/app/package.json
@@ -29,6 +29,7 @@
     "react-i18next": "^13.0.0"
   },
   "devDependencies": {
+    "@ianvs/prettier-plugin-sort-imports": "^4.0.2",
     "@storybook/addon-essentials": "^7.0.23",
     "@storybook/nextjs": "^7.0.23",
     "@storybook/react": "^7.0.23",
@@ -36,7 +37,6 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
-    "@trivago/prettier-plugin-sort-imports": "^4.1.1",
     "@types/jest-axe": "^3.5.5",
     "@types/node": "^18.15.3",
     "@types/react": "^18.0.28",

--- a/app/src/components/Footer.tsx
+++ b/app/src/components/Footer.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next";
 import {
   Address,
   FooterNav,
@@ -5,7 +6,6 @@ import {
   GridContainer,
   Footer as USWDSFooter,
 } from "@trussworks/react-uswds";
-import { useTranslation } from "next-i18next";
 
 const Footer = () => {
   const { t } = useTranslation("common", {

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from "next-i18next";
+import { useState } from "react";
 import {
   GovBanner,
   NavMenuButton,
@@ -5,8 +7,6 @@ import {
   Title,
   Header as USWDSHeader,
 } from "@trussworks/react-uswds";
-import { useTranslation } from "next-i18next";
-import { useState } from "react";
 
 const primaryLinks: {
   i18nKey: string;

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -1,7 +1,7 @@
-import { Grid, GridContainer } from "@trussworks/react-uswds";
 import { useTranslation } from "next-i18next";
+import { Grid, GridContainer } from "@trussworks/react-uswds";
 
-import Footer from "./Footer";
+import Footer from "src/components/Footer";
 import Header from "./Header";
 
 type Props = {

--- a/app/src/pages/_app.tsx
+++ b/app/src/pages/_app.tsx
@@ -3,6 +3,7 @@ import type { AppProps } from "next/app";
 import Head from "next/head";
 
 import "../../styles/styles.scss";
+
 import Layout from "../components/Layout";
 
 function MyApp({ Component, pageProps }: AppProps) {

--- a/app/src/pages/health.tsx
+++ b/app/src/pages/health.tsx
@@ -1,4 +1,5 @@
 import type { GetServerSideProps, NextPage } from "next";
+
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import React from "react";
 

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import type { GetServerSideProps, NextPage } from "next";
+
 import { Trans, useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Head from "next/head";

--- a/app/stories/components/Layout.stories.tsx
+++ b/app/stories/components/Layout.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta } from "@storybook/react";
+
 import Layout from "src/components/Layout";
 
 const meta: Meta<typeof Layout> = {

--- a/app/tests/components/Header.test.tsx
+++ b/app/tests/components/Header.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+
 import Header from "src/components/Header";
 
 describe("Header", () => {

--- a/app/tests/components/Layout.test.tsx
+++ b/app/tests/components/Layout.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
+
 import Layout from "src/components/Layout";
 
 describe("Layout", () => {

--- a/app/tests/jest-i18n.ts
+++ b/app/tests/jest-i18n.ts
@@ -2,12 +2,12 @@
  * @file Setup internationalization for tests so snapshots and queries reference the correct translations
  */
 import fs from "fs";
-import i18n, { InitOptions } from "i18next";
 import path from "path";
-import { initReactI18next } from "react-i18next";
 
 // @ts-expect-error - Config file has to be .js
 import i18nConfig from "../next-i18next.config";
+import i18n, { InitOptions } from "i18next";
+import { initReactI18next } from "react-i18next";
 
 const locales = i18nConfig.i18n.locales;
 


### PR DESCRIPTION
## Ticket

#151

## Changes

- Replaced `@trivago/prettier-plugin-sort-imports` with `@ianvs/prettier-plugin-sort-imports`
- Migrated the Prettier config file to a type-checked JS file

## Context for reviewers

The new plugin we're using in this PR has the following advantages:

- Does not re-order across side-effect imports
- Combines imports from the same source
- Combines type and value imports
- Type import grouping is possible with `<TYPES>` keyword
- Can sort node.js builtin modules