### PR TITLE
Move dependencies to their own stage

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -2,9 +2,12 @@
 # Next.js Docker example: https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose
 # =============================================================================
 FROM node:18-alpine AS base
+
+# Install dependencies in a separate stage so that they
+# are excluded from the final production release stage
+FROM base as dev-dependencies
 WORKDIR /app
 
-# Install dependencies
 COPY package.json package-lock.json ./
 COPY public ./public
 COPY scripts ./scripts
@@ -13,7 +16,7 @@ RUN npm ci --no-audit
 # =============================================================================
 # Development stage
 # =============================================================================
-FROM base AS dev
+FROM dev-dependencies AS dev
 WORKDIR /app
 
 COPY tsconfig.json .
@@ -33,7 +36,7 @@ CMD ["npm", "run", "dev"]
 
 # Build the Next.js app
 # =====================================
-FROM base AS builder
+FROM dev-dependencies AS builder
 WORKDIR /app
 
 COPY tsconfig.json .


### PR DESCRIPTION
## Context for reviewers

The vulnerability scanner was still reporting vulnerabilities related to development dependencies because [the release stage is built off of base](https://github.com/navapbc/platform-test-nextjs/blob/main/app/Dockerfile#L58) and [base has all the dependencies including the dev ones](https://github.com/navapbc/platform-test-nextjs/blob/main/app/Dockerfile#L7-L11).

## Testing

**Before**

![image](https://github.com/navapbc/template-application-nextjs/assets/371943/b3f6e305-b2b6-4ed7-afe3-afd960085821)

**After**

![image](https://github.com/navapbc/template-application-nextjs/assets/371943/0cb94f84-3147-4f8f-ade4-95848ddd9bd6)
