### PR TITLE
Fix semver vulnerability in base image

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -59,10 +59,9 @@ RUN npm run build -- --no-lint
 FROM node:18-bullseye-slim AS release
 WORKDIR /app
 
-# As of July 13, 2023, 18-bullseye-slim has a vulnerability in the version of
-# semver that it uses (GHSA-c2qf-rxjj-qqgw). Update npm to avoid the vulnerability
-# being caught in vulnerability scans.
-RUN npm install -g npm@latest
+# Release stage doesn't have a need for `npm`, so remove it to avoid 
+# any vulnerabilities specific to NPM
+RUN npm uninstall -g npm
 
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 # This file is largely based on the template-application-flask Dockerfile and
 # Next.js Docker example: https://github.com/vercel/next.js/blob/canary/examples/with-docker-compose
 # =============================================================================
-FROM node:18-alpine AS base
+FROM node:18-bullseye-slim AS base
 WORKDIR /app
 
 # Install dependencies
@@ -56,8 +56,13 @@ RUN npm run build -- --no-lint
 # Run the Next.js server
 # =====================================
 # Use clean image for release, excluding any unnecessary files or dependencies
-FROM node:18-alpine AS release
+FROM node:18-bullseye-slim AS release
 WORKDIR /app
+
+# As of July 13, 2023, 18-bullseye-slim has a vulnerability in the version of
+# semver that it uses (GHSA-c2qf-rxjj-qqgw). Update npm to avoid the vulnerability
+# being caught in vulnerability scans.
+RUN npm install -g npm@latest
 
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs

--- a/app/Makefile
+++ b/app/Makefile
@@ -27,6 +27,7 @@ export RUN_UID
 ##################################################
 release-build:
 	docker buildx build \
+	  --target release \
 		--platform=linux/amd64 \
 		--build-arg RUN_USER=$(RUN_USER) \
 		--build-arg RUN_UID=$(RUN_UID) \


### PR DESCRIPTION
## Ticket

n/a

## Changes
* Fix semver vulnerability in base image
* Target release stage explicitly in make release-build

## Context for reviewers
Tackling the stubborn last vulnerability in the anchor scan

## Testing
Made the changes in platform-test-nextjs repo in this PR: https://github.com/navapbc/platform-test-nextjs/pull/79
- You can see that the scans all pass!
- Also triggered e2e tests to show that the service still works