### PR TITLE
Remove yarn from Docker release stage

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -59,9 +59,11 @@ RUN npm run build -- --no-lint
 FROM node:18-bullseye-slim AS release
 WORKDIR /app
 
-# Release stage doesn't have a need for `npm`, so remove it to avoid 
+# Release stage doesn't have a need for `npm`, so remove it to avoid
 # any vulnerabilities specific to NPM
 RUN npm uninstall -g npm
+# Remove yarn as well (https://github.com/nodejs/docker-node/issues/777)
+RUN rm -rf /opt/yarn-v*
 
 # Don't run production as root
 RUN addgroup --system --gid 1001 nodejs


### PR DESCRIPTION
## Changes

- Update `Dockerfile` release stage to remove `yarn`, for similar reasons as #175 

## Context for reviewers

- Even though Yarn isn't included in the official Node installation, [the Docker image does install it](https://github.com/nodejs/docker-node/blob/31bc0387d4a2eea9e9fee4d5b1f8dca0e0596dca/18/bullseye-slim/Dockerfile#L56-L88).
- Issue from 2018 asking for it to not be in the official image, but seems unlikely to be going away: https://github.com/nodejs/docker-node/issues/777

## Testing

<img width="706" alt="CleanShot 2023-07-13 at 16 09 56@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/ee22497c-48ec-42ea-be07-a536df21c4d0">

