### PR TITLE
Add wget to release build

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -59,6 +59,15 @@ RUN npm run build -- --no-lint
 FROM node:18-bullseye-slim AS release
 WORKDIR /app
 
+RUN apt-get update \
+    # Install security updates
+    # https://pythonspeed.com/articles/security-updates-in-docker/
+    && apt-get upgrade --yes \
+    # Install wget, required for health checks
+    wget \
+    # Reduce the image size by clearing apt cached lists
+    && rm -fr /var/lib/apt/lists/*
+
 # Release stage doesn't have a need for `npm`, so remove it to avoid
 # any vulnerabilities specific to NPM
 RUN npm uninstall -g npm


### PR DESCRIPTION
## Ticket

n/a

## Changes
- Add wget to release build
- Also port over the `apt-get upgrade` and removal of apt cache lists, since those seemed like good ideas too
  - from https://github.com/navapbc/template-application-flask/blob/main/app/Dockerfile#L21

## Context for reviewers
 - wget is required for health checks

## Testing
<img width="264" alt="image" src="https://github.com/navapbc/template-application-nextjs/assets/31424131/6de95bbe-c2e9-4673-b0dd-f69d416fae63">