### PR TITLE
Set default i18n namespace to fix slow Storybook+Chromatic behavior

### DIFF
--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -15,6 +15,11 @@ const i18n = {
  * https://react.i18next.com/latest/i18next-instance
  */
 const i18next = {
+  // Default namespace to load, typically overridden within components,
+  // but set here to prevent the system from attempting to load
+  // translation.json, which is the default, and doesn't exist
+  // in this codebase
+  ns: "common",
   defaultNS: "common",
   fallbackLng: i18n.defaultLocale,
   interpolation: {

--- a/app/next-i18next.config.js
+++ b/app/next-i18next.config.js
@@ -1,6 +1,8 @@
+// @ts-check
 /**
  * Next.js i18n routing options
  * https://nextjs.org/docs/advanced-features/i18n-routing
+ * @type {import('next').NextConfig['i18n']}
  */
 const i18n = {
   defaultLocale: "en",
@@ -13,6 +15,7 @@ const i18n = {
  * i18next and react-i18next options
  * https://www.i18next.com/overview/configuration-options
  * https://react.i18next.com/latest/i18next-instance
+ * @type {import("i18next").InitOptions}
  */
 const i18next = {
   // Default namespace to load, typically overridden within components,
@@ -30,6 +33,7 @@ const i18next = {
 /**
  * next-i18next options
  * https://github.com/i18next/next-i18next#options
+ * @type {Partial<import("next-i18next").UserConfig>}
  */
 const nextI18next = {
   // Locale resources are loaded once when the server is started, which
@@ -38,6 +42,9 @@ const nextI18next = {
   reloadOnPrerender: process.env.NODE_ENV === "development",
 };
 
+/**
+ * @type {import("next-i18next").UserConfig}
+ */
 module.exports = {
   i18n,
   ...i18next,


### PR DESCRIPTION
## Changes

- Define which i18n namespace should be loaded if not defined at the page/component level. This fixes an issue I observed when Storybook is deployed to Chromatic, where Chromatic would be very slow to load because it attempts to load `translation.json` which is the default `ns` when it's not defined in the config.

## Context for reviewers

https://www.i18next.com/overview/configuration-options#languages-namespaces-resources

## Testing

### Before, in Chromatic

It would make several attempts to load the translation file, and would only render the story after six failed requests:

<img width="1681" alt="CleanShot 2023-08-04 at 14 24 34@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/a48584d5-42c1-4cad-babd-db769ba5360a">

### After, in Chromatic

No errors, and the Story loads right away

<img width="1487" alt="CleanShot 2023-08-04 at 14 26 49@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/1c2ef56e-86cd-4c4f-9c93-92c96eabed15">
