### PR TITLE
Use `docker compose` in `make stop`

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -46,4 +46,4 @@ storybook: # Run the Storybook local dev server in Docker
 	docker compose logs --follow storybook
 
 stop:
-	docker-compose down
+	docker compose down


### PR DESCRIPTION
## Context for reviewers

All of the other scripts use `docker compose` but this one was using `docker-compose` which I think is an old way of running this.