### PR TITLE
Use HTML comments in PR template; Update suggested GIF record.

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,12 +4,12 @@ Resolves #{TICKET NUMBER OR URL}
 
 ## Changes
 
-> What was added, updated, or removed in this PR.
+<!-- What was added, updated, or removed in this PR. -->
 
 ## Context for reviewers
 
-> Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers.
+<!-- Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. -->
 
 ## Testing
 
-> Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://www.cockos.com/licecap/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox.
+<!-- Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://getkap.co/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox. -->


### PR DESCRIPTION
## Changes

- Update the PR template to use HTML comments, so that they aren't rendered in the published PR request.
- Replace LICECap with Kap as the recommended GIF recorder. Kap is newer and more maintained. I don't think LICECap works on M1 Macbooks for instance.