### PR TITLE
Add lint rule to require imports from next-i18next rather than react-i18next

### DIFF
--- a/app/.eslintrc.js
+++ b/app/.eslintrc.js
@@ -14,6 +14,19 @@ module.exports = {
     // dependencies to work in standalone mode. It may be overkill for most projects at
     // Nava which aren't image heavy.
     "@next/next/no-img-element": "off",
+    "no-restricted-imports": [
+      "error",
+      {
+        paths: [
+          {
+            message:
+              'Import from "next-i18next" instead of "react-i18next" so server-side translations work.',
+            name: "react-i18next",
+            importNames: ["useTranslation", "Trans"],
+          },
+        ],
+      },
+    ],
   },
   // Additional lint rules. These get layered onto the top-level rules.
   overrides: [

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -46,8 +46,8 @@ I18next is configured to report errors if you attempt to reference an i18n key p
    import { Trans, useTranslation } from "next-i18next";
 
    const Page = () => {
-     // Optionally pass in the namespace of the translation file (e.g. common) to use
-     const { t } = useTranslation("common");
+     const { t } = useTranslation();
+
      return (
        <>
          <h1>{t("About.title")}</h1>
@@ -55,6 +55,16 @@ I18next is configured to report errors if you attempt to reference an i18n key p
        </>
      );
    };
+   ```
+
+   By default, `useTranslation` and `Trans` load translations from the `common` namespace. To load translations from a different namespace, you can pass the `ns` prop to `Trans`, or the `ns` option to `useTranslation`.
+
+   ```tsx
+   const { t } = useTranslation("someOtherNamespace");
+   ```
+
+   ```tsx
+   <Trans ns="someOtherNamespace" i18nKey="someKey" />
    ```
 
 Refer to the [i18next](https://www.i18next.com/) and [react-i18next](https://react.i18next.com/) documentation for more usage docs.


### PR DESCRIPTION
## Changes

- Add lint rule to require imports from `next-i18next` rather than `react-i18next`, otherwise the site will report hydration errors due to server-side renders not outputting the translated text
- Update docs to clarify how i18n namespaces work

## Testing

<img width="1220" alt="CleanShot 2023-09-18 at 09 10 37@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/4a384277-562f-4802-921e-4fe721deaedb">

