### PR TITLE
Add missing Jest types package

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -11,6 +11,7 @@
 # next.js
 /.next/
 /out/
+.swc
 
 # production
 /build

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -27,6 +27,7 @@
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^14.0.0",
         "@testing-library/user-event": "^14.4.3",
+        "@types/jest": "^29.5.5",
         "@types/jest-axe": "^3.5.5",
         "@types/node": "^18.15.3",
         "@types/react": "^18.0.28",
@@ -7800,9 +7801,9 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "29.5.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
-      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
+      "version": "29.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
+      "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
       "dev": true,
       "dependencies": {
         "expect": "^29.0.0",
@@ -28422,9 +28423,9 @@
       }
     },
     "@types/jest": {
-      "version": "29.5.2",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.2.tgz",
-      "integrity": "sha512-mSoZVJF5YzGVCk+FsDxzDuH7s+SCkzrgKZzf0Z0T2WudhBUPoF6ktoTPC4R0ZoCPCV5xUvuU6ias5NvxcBcMMg==",
+      "version": "29.5.5",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
+      "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
       "dev": true,
       "requires": {
         "expect": "^29.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -40,6 +40,7 @@
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^29.5.5",
     "@types/jest-axe": "^3.5.5",
     "@types/node": "^18.15.3",
     "@types/react": "^18.0.28",


### PR DESCRIPTION
## Changes

- Fix issue where some projects weren't getting the Jest types, which makes sense, since we aren't installing the package as a direct dependency: https://jestjs.io/docs/getting-started#type-definitions
- Ignore generated files when running tests