### PR TITLE
Set consistent timezone for tests

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,9 +16,9 @@
     "start": "next start -p ${PORT:-3000}",
     "storybook": "storybook dev -p 6006",
     "storybook-build": "storybook build",
-    "test": "jest --ci --coverage",
-    "test-update": "jest --update-snapshot",
-    "test-watch": "jest --watch",
+    "test": "TZ=America/New_York jest --ci --coverage",
+    "test-update": "TZ=America/New_York jest --update-snapshot",
+    "test-watch": "TZ=America/New_York jest --watch",
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
## Changes

- Fix common issue where a test passes locally, but fails in the CI or on other engineers' machines, because of a difference in timezone