### PR TITLE
Revert "Set consistent timezone for tests (#209)"

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -16,9 +16,9 @@
     "start": "next start -p ${PORT:-3000}",
     "storybook": "storybook dev -p 6006",
     "storybook-build": "storybook build",
-    "test": "TZ=America/New_York jest --ci --coverage",
-    "test-update": "TZ=America/New_York jest --update-snapshot",
-    "test-watch": "TZ=America/New_York jest --watch",
+    "test": "jest --ci --coverage",
+    "test-update": "jest --update-snapshot",
+    "test-watch": "jest --watch",
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {


### PR DESCRIPTION
This reverts commit 5db0ceaac6f2625e6392d87b020ee55f23bb5f3b.

## Context for reviewers

Projects can mock timezone within the relevant tests. Mocking globally could hide bugs. See convo on #209.