### PR TITLE
Enable global USWDS typography styles

### DIFF
--- a/app/.storybook/preview.js
+++ b/app/.storybook/preview.js
@@ -23,6 +23,22 @@ const parameters = {
   },
   // Configure i18next and locale/dropdown options.
   i18n,
+  options: {
+    storySort: {
+      method: "alphabetical",
+      order: [
+        "Welcome",
+        "Core",
+        // Storybook infers the title when not explicitly set, but is case-sensitive
+        // so we need to explicitly set both casings here for this to properly sort.
+        "Components",
+        "components",
+        "Templates",
+        "Pages",
+        "pages",
+      ],
+    },
+  },
 };
 
 /**

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -12,10 +12,8 @@ const Home: NextPage = () => {
       <Head>
         <title>{t("title")}</title>
       </Head>
-      {/* Demonstration of responsive utility classes: */}
-      <h1 className="font-sans-2xl tablet:font-sans-3xl margin-y-3 tablet:margin-top-6">
-        {t("title")}
-      </h1>
+
+      <h1>{t("title")}</h1>
 
       {/* Demonstration of more complex translated strings, with safe-listed links HTML elements */}
       <p className="usa-intro">

--- a/app/src/styles/_uswds-theme.scss
+++ b/app/src/styles/_uswds-theme.scss
@@ -18,7 +18,7 @@ for a full list of available settings.
   // Ensure utility classes always override other styles
   $utilities-use-important: true,
 
-  // Prettier defaults for typography
+  // Use USWDS defaults for typography
   $theme-style-body-element: true,
   $theme-font-type-sans: "public-sans",
   $theme-global-link-styles: true,

--- a/app/src/styles/_uswds-theme.scss
+++ b/app/src/styles/_uswds-theme.scss
@@ -21,7 +21,7 @@ for a full list of available settings.
   // Use USWDS defaults for typography
   $theme-style-body-element: true,
   $theme-font-type-sans: "public-sans",
+  $theme-global-content-styles: true,
   $theme-global-link-styles: true,
-  $theme-global-paragraph-styles: true,
-  $theme-global-content-styles: true
+  $theme-global-paragraph-styles: true
 );

--- a/app/src/styles/_uswds-theme.scss
+++ b/app/src/styles/_uswds-theme.scss
@@ -1,9 +1,9 @@
 /*
 ----------------------------------------
-USWDS with settings overrides
+USWDS settings overrides
 ----------------------------------------
-Uncomment the following lines and add a list of changed settings
-in the form $setting: value,
+See https://designsystem.digital.gov/documentation/settings/
+for a full list of available settings.
 ----------------------------------------
 */
 
@@ -19,6 +19,9 @@ in the form $setting: value,
   $utilities-use-important: true,
 
   // Prettier defaults for typography
+  $theme-style-body-element: true,
   $theme-font-type-sans: "public-sans",
-  $theme-global-link-styles: true
+  $theme-global-link-styles: true,
+  $theme-global-paragraph-styles: true,
+  $theme-global-content-styles: true
 );

--- a/app/stories/typography.stories.tsx
+++ b/app/stories/typography.stories.tsx
@@ -1,0 +1,67 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+const meta: Meta = {
+  title: "Core/Typography",
+};
+
+export default meta;
+
+export const GlobalStyles: StoryObj = {
+  render: () => (
+    <>
+      <h1>Heading 1</h1>
+      <h2>Heading 2</h2>
+      <h3>Heading 3</h3>
+      <h4>Heading 4</h4>
+      <h5>Heading 5</h5>
+      <h6>Heading 6</h6>
+      <p className="usa-intro">Intro text</p>
+      <p>Paragraph text</p>
+      <p>
+        <a href="#">Link</a>
+      </p>
+      <p>
+        <a href="#" className="usa-link--external">
+          External link
+        </a>
+      </p>
+      <ul>
+        <li>Unordered list item: A</li>
+        <li>Unordered list item: B</li>
+      </ul>
+      <ol>
+        <li>Ordered list item</li>
+        <li>Ordered list item</li>
+      </ol>
+    </>
+  ),
+};
+
+export const ResponsiveUtilities: StoryObj = {
+  render: () => (
+    <>
+      <h1 className="font-heading-lg tablet:font-heading-xl desktop:font-heading-2xl">
+        Responsive heading
+        <br />
+        (lg on mobile, xl on tablet, 2xl on desktop)
+      </h1>
+      <p className="font-body-2xs tablet:font-body-sm desktop:font-body-md">
+        Responsive paragraph
+        <br />
+        (2xs on mobile, sm on tablet, md on desktop)
+      </p>
+    </>
+  ),
+};
+
+export const ColorUtilities: StoryObj = {
+  render: () => (
+    <>
+      <h1>Examples of text color utility classes (not comprehensive):</h1>
+      <p className="text-base">Base</p>
+      <p className="text-accent-warm-dark">Accent warm dark</p>
+      <p className="text-success-dark">Success dark</p>
+      <p className="text-error-dark">Error dark</p>
+    </>
+  ),
+};

--- a/app/stories/typography.stories.tsx
+++ b/app/stories/typography.stories.tsx
@@ -18,9 +18,7 @@ export const GlobalStyles: StoryObj = {
       <p className="usa-intro">Intro text</p>
       <p>Paragraph text</p>
       <p>
-        <a href="#">Link</a>
-      </p>
-      <p>
+        <a href="#">Link</a> and{" "}
         <a href="#" className="usa-link--external">
           External link
         </a>
@@ -33,6 +31,25 @@ export const GlobalStyles: StoryObj = {
         <li>Ordered list item</li>
         <li>Ordered list item</li>
       </ol>
+    </>
+  ),
+};
+
+export const SizeUtilities: StoryObj = {
+  render: () => (
+    <>
+      <h1 className="font-heading-lg">H1 with smaller text size</h1>
+      <h2 className="font-heading-2xl">H2 with larger text size</h2>
+      <p className="font-body-2xs">Extra extra small paragraph</p>
+    </>
+  ),
+};
+
+export const FamilyUtilities: StoryObj = {
+  render: () => (
+    <>
+      <h1 className="font-family-sans">Sans heading</h1>
+      <p className="font-family-serif">Serif body</p>
     </>
   ),
 };


### PR DESCRIPTION
## Changes

- Enable USWDS settings to apply global typography styles (size, color, spacing)
- Add a new Typography storybook section for previewing global type styles and provide examples of using typography utility classes

## Context for reviewers

The intent (I think) of these USWDS settings being disabled by default is to not interfere with a site's existing styles. The downside is teams must apply a good bit of the utility classes in order to style headings and paragraphs the way they want. 

The intent of the template is to help teams quickly create new applications, so the risk of interfering with an existing site's styles isn't as applicable, and it would be more beneficial to have global styles from the start, to reduce the need for utility classes.

## Testing

<img width="952" alt="CleanShot 2023-09-18 at 18 22 48@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/d9556c77-5689-4da3-8cb4-9530ca086286">

