### PR TITLE
Fix broken experience for older Safari and Edge

### DIFF
--- a/app/next.config.js
+++ b/app/next.config.js
@@ -25,6 +25,7 @@ const nextConfig = {
   transpilePackages: [
     // https://github.com/i18next/i18next/issues/1948
     "i18next",
+    "react-i18next",
     // https://github.com/trussworks/react-uswds/issues/2605
     "@trussworks/react-uswds",
   ],

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -21,10 +21,12 @@ const nextConfig = {
   // https://nextjs.org/docs/app/api-reference/next-config-js/output
   output: "standalone",
   sassOptions: appSassOptions,
+  // Continue to support older browsers (ES5)
   transpilePackages: [
-    // Continue to support older browsers (ES5)
     // https://github.com/i18next/i18next/issues/1948
     "i18next",
+    // https://github.com/trussworks/react-uswds/issues/2605
+    "@trussworks/react-uswds",
   ],
 };
 


### PR DESCRIPTION
## Changes

- Configures Next.js to transpile the React USWDS and React I18next packages to address an issue where its syntax was breaking the experience for Safari versions prior to 14, and Edge versions prior to 79.

## Context for reviewers

I've filed a ticket on the React USWDS repo about one of the issues here: https://github.com/trussworks/react-uswds/issues/2605

The two JS exceptions we were seeing are:

1. [`Unexpected token '='`](https://stackoverflow.com/questions/60026651/safari-unexpected-token-expected-an-opening-before-a-methods-paramet)
2. [`Expected identifier, string or number`](https://confluence.atlassian.com/insightapps/known-issue-with-older-versions-of-microsoft-edge-1085191263.html)

## Testing

Before

<img width="1070" alt="CleanShot 2023-09-29 at 12 49 11@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/e6680fd5-8bf3-4165-a9ef-c4a6aa6fa3b4">

After

<img width="1069" alt="CleanShot 2023-09-29 at 12 47 49@2x" src="https://github.com/navapbc/template-application-nextjs/assets/371943/d02a4f71-e5d3-4e21-bae2-83d2de83f10c">
