### PR TITLE
Fix sticky footer and health page i18n + update documentation

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -105,9 +105,9 @@ From the `app/` directory:
 
 ## 🐛 Testing
 
-[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are manged as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
+[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are managed as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
 
-Tests are manged as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
+Tests are managed as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
 
 To run tests:
 

--- a/app/README.md
+++ b/app/README.md
@@ -10,7 +10,6 @@
 ```
 ├── .storybook        # Storybook configuration
 ├── public            # Static assets
-│   └── locales       # Internationalized content
 ├── src               # Source code
 │   ├── components    # Reusable UI components
 │   ├── i18n          # Internationalization
@@ -106,7 +105,7 @@ From the `app/` directory:
 
 ## 🐛 Testing
 
-[Jest](https://jestjs.io/docs/getting-started) is used as the test runner and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) provides React testing utilities.
+[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are manged as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
 
 Tests are manged as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
 
@@ -120,6 +119,25 @@ A subset of tests can be ran by passing a pattern to the script. For example, to
 
 ```sh
 npm run test-watch -- pages
+```
+
+### Testing React components
+
+[React Testing Library (RTL)](https://testing-library.com/docs/react-testing-library/intro) provides the utilities for rendering and querying, and [`jest-axe`](https://www.npmjs.com/package/jest-axe) is used for accessibility testing. Refer to their docs to learn more about their APIs, or view an existing test for examples.
+
+`@testing-library/react` methods should be imported from `tests/react-utils` in order for internationalization to work within your tests:
+
+```diff
+- import { render, screen } from '@testing-library/react';
++ import { render, screen } from 'tests/react-utils';
+
+it("renders submit button", () => {
+  render(<Page />)
+
+  expect(
+    screen.getByRole("button", { name: "Submit" })
+  ).toBeInTheDocument()
+})
 ```
 
 ## 🤖 Type checking, linting, and formatting

--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -9,10 +9,7 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 /** @type {import('jest').Config} */
 const customJestConfig = {
-  setupFilesAfterEnv: [
-    "<rootDir>/tests/jest.setup.ts",
-    "<rootDir>/tests/jest-i18n.ts",
-  ],
+  setupFilesAfterEnv: ["<rootDir>/tests/jest.setup.ts"],
   testEnvironment: "jsdom",
   // if using TypeScript with a baseUrl set to the root directory then you need the below for alias' to work
   moduleDirectories: ["node_modules", "<rootDir>/"],

--- a/app/src/components/Layout.tsx
+++ b/app/src/components/Layout.tsx
@@ -20,7 +20,8 @@ const Layout = ({ children, locale }: Props) => {
       </a>
       <GovBanner language={locale?.match(/^es-?/) ? "spanish" : "english"} />
       <Header />
-      <main id="main-content" className="usa-section">
+      {/* grid-col-fill so that the footer sticks to the bottom of tall screens */}
+      <main id="main-content" className="usa-section grid-col-fill">
         <GridContainer>
           <Grid row>
             <Grid col>{children}</Grid>

--- a/app/src/pages/health.tsx
+++ b/app/src/pages/health.tsx
@@ -1,4 +1,15 @@
+import { GetServerSideProps } from "next";
+import { getMessagesWithFallbacks } from "src/i18n/getMessagesWithFallbacks";
+
 import React from "react";
+
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => {
+  return {
+    props: {
+      messages: await getMessagesWithFallbacks(locale),
+    },
+  };
+};
 
 const Health = () => {
   return <>healthy</>;

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -13,6 +13,20 @@ interface PageProps {
   isFooEnabled: boolean;
 }
 
+// Change this to getStaticProps if you're not using server-side rendering
+export const getServerSideProps: GetServerSideProps<PageProps> = async ({
+  locale,
+}) => {
+  const isFooEnabled = await isFeatureEnabled("foo", "anonymous");
+
+  return {
+    props: {
+      messages: await getMessagesWithFallbacks(locale),
+      isFooEnabled,
+    },
+  };
+};
+
 const Home: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> = (
   props
 ) => {
@@ -54,20 +68,6 @@ const Home: NextPage<InferGetServerSidePropsType<typeof getServerSideProps>> = (
       </div>
     </>
   );
-};
-
-// Change this to getStaticProps if you're not using server-side rendering
-export const getServerSideProps: GetServerSideProps<PageProps> = async ({
-  locale,
-}) => {
-  const isFooEnabled = await isFeatureEnabled("foo", "anonymous");
-
-  return {
-    props: {
-      messages: await getMessagesWithFallbacks(locale),
-      isFooEnabled,
-    },
-  };
 };
 
 export default Home;

--- a/app/tests/jest-i18n.ts
+++ b/app/tests/jest-i18n.ts
@@ -1,3 +1,0 @@
-/**
- * @file Setup internationalization for tests so snapshots and queries reference the correct translations
- */

--- a/docs/internationalization.md
+++ b/docs/internationalization.md
@@ -1,7 +1,7 @@
 # Internationalization (i18n)
 
 - [next-intl](https://next-intl-docs.vercel.app) is used for internationalization. Toggling between languages is done by changing the URL's path prefix (e.g. `/about` ➡️ `/es-US/about`).
-- Configuration and helpers are located in [`i18n/config.ts`](../app/src/i18n/config.ts). For the most part, you shouldn't need to edit this file unless adding a new formatter or new language.
+- Configuration is located in [`i18n/config.ts`](../app/src/i18n/config.ts). For the most part, you shouldn't need to edit this file unless adding a new formatter or new language.
 
 ## Managing translations
 


### PR DESCRIPTION
## Changes

Various fixes I originally had made in the App Router migration branch, which is now on pause, so pulling over into `main`

- Fix sticky footer
- Expand testing docs and fix file structure 
- Remove unused jest setup file
- Fix i18n on health page
- Move `getServerSideProps` to top of each file

## Testing

![CleanShot 2023-12-12 at 17 07 32@2x](https://github.com/navapbc/template-application-nextjs/assets/371943/5d1c1b1f-aaeb-4f3d-b637-583e6742d096)
