### PR TITLE
Add GH Actions Workflow for Code Coverage Reporting

### DIFF
--- a/.github/workflows/ci-jest-coverage.yml
+++ b/.github/workflows/ci-jest-coverage.yml
@@ -1,0 +1,12 @@
+name: 'coverage'
+on:
+    pull_request:
+        branches:
+            - master
+            - main
+jobs:
+    coverage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: ArtiomTr/jest-coverage-report-action@v2


### PR DESCRIPTION
## Ticket

Resolves #106

## Changes

added GH Actions workflow that uses [an existing Marketplace script](https://github.com/marketplace/actions/jest-coverage-report) to provide Jest code coverage reports on PRs