### PR TITLE
Colocate Test and Story Files with Code

### DIFF
--- a/app/.storybook/main.js
+++ b/app/.storybook/main.js
@@ -24,7 +24,10 @@ function blockSearchEnginesInHead(head) {
  * @type {import("@storybook/nextjs").StorybookConfig}
  */
 const config = {
-  stories: ["../stories/**/*.stories.@(mdx|js|jsx|ts|tsx)"],
+  stories: [
+    "../stories/**/*.stories.@(mdx|js|jsx|ts|tsx)",
+    "../src/**/*.stories.@(mdx|js|jsx|ts|tsx)",
+  ],
   addons: ["@storybook/addon-essentials"],
   framework: {
     name: "@storybook/nextjs",

--- a/app/README.md
+++ b/app/README.md
@@ -112,10 +112,10 @@ To run tests:
 - `npm run test-update` - Updates test snapshots
 - `npm run test-watch` - Runs tests in [watch](https://jestjs.io/docs/cli#--watch) mode. Tests will re-run when files are changed, and an interactive prompt will allow you to run specific tests or update snapshots.
 
-A subset of tests can be ran by passing a pattern to the script. For example, to only run tests in `tests/pages/`:
+A subset of tests can be ran by passing a pattern to the script. For example, to only run tests in `app/components`:
 
 ```sh
-npm run test-watch -- pages
+npm run test-watch -- app/components
 ```
 
 ### Testing React components

--- a/app/README.md
+++ b/app/README.md
@@ -104,9 +104,7 @@ From the `app/` directory:
 
 ## 🐛 Testing
 
-[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are managed as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
-
-Tests are managed as `.test.ts` (or `.tsx`) files in the the `tests/` directory.
+[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are managed as `.test.ts` (or `.tsx`) files and are colocated with the files they reference (for unit tests).
 
 To run tests:
 

--- a/app/README.md
+++ b/app/README.md
@@ -104,7 +104,7 @@ From the `app/` directory:
 
 ## 🐛 Testing
 
-[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are managed as `.test.ts` (or `.tsx`) files and are colocated with the files they reference (for unit tests).
+[Jest](https://jestjs.io/docs/getting-started) is used as the test runner. Tests are managed as `.test.ts` (or `.test.tsx`) files and are colocated with the files they reference (for unit tests).
 
 To run tests:
 

--- a/app/src/app/[locale]/page.stories.tsx
+++ b/app/src/app/[locale]/page.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta } from "@storybook/react";
-import { View } from "src/app/[locale]/view";
+
+import { View } from "./view";
 
 const meta: Meta<typeof View> = {
   title: "Pages/Home",

--- a/app/src/app/[locale]/page.test.tsx
+++ b/app/src/app/[locale]/page.test.tsx
@@ -1,8 +1,9 @@
 import { axe } from "jest-axe";
-import Controller from "src/app/[locale]/page";
-import { View } from "src/app/[locale]/view";
 import { LocalFeatureFlagManager } from "src/services/feature-flags/LocalFeatureFlagManager";
 import { cleanup, render, screen } from "tests/react-utils";
+
+import Controller from "./page";
+import { View } from "./view";
 
 describe("Index - Controller", () => {
   it("retrieves feature flags", async () => {

--- a/app/src/components/Header.test.tsx
+++ b/app/src/components/Header.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { render, screen } from "tests/react-utils";
 
-import Header from "src/components/Header";
+import Header from "./Header";
 
 describe("Header", () => {
   it("toggles the mobile nav menu", async () => {

--- a/app/src/components/Layout.stories.tsx
+++ b/app/src/components/Layout.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta } from "@storybook/react";
 import { defaultLocale } from "src/i18n/config";
 
-import Layout from "src/components/Layout";
+import Layout from "./Layout";
 
 const meta: Meta<typeof Layout> = {
   component: Layout,

--- a/app/src/components/Layout.test.tsx
+++ b/app/src/components/Layout.test.tsx
@@ -1,7 +1,7 @@
 import { axe } from "jest-axe";
 import { render, screen } from "tests/react-utils";
 
-import Layout from "src/components/Layout";
+import Layout from "./Layout";
 
 describe("Layout", () => {
   it("renders children in main section", () => {


### PR DESCRIPTION
## Ticket

Resolves #271

## Changes

- move existing unit test files into same folder with the file they reference
- move existing Storybook story files into same folder with the file they reference
- update Storybook config to load files from anywhere under `src` folder
