### PR TITLE
Added basic support for local feature flagging

### DIFF
--- a/app/.env.development
+++ b/app/.env.development
@@ -11,3 +11,8 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 FEATURE_FLAGS_PROJECT=
 AWS_REGION=
+
+# Feature flags
+# Flags for browser should be prefaced with NEXT_PUBLIC_FEATURE_
+# Flags for server should be prefaced with FEATURE_
+NEXT_PUBLIC_FEATURE_foo=false

--- a/app/src/services/feature-flags/LocalFeatureFlagManager.ts
+++ b/app/src/services/feature-flags/LocalFeatureFlagManager.ts
@@ -1,6 +1,22 @@
 export class LocalFeatureFlagManager {
   async isFeatureEnabled(featureName: string, userId: string) {
-    console.log("Using mock feature flag manager", { featureName, userId });
-    return Promise.resolve(false);
+    // Note: feature flag env variables should be prefixed with "FEATURE_" or "NEXT_PUBLIC_FEATURE_"
+    // "FEATURE_" is used for server-side feature flags
+    // "NEXT_PUBLIC_FEATURE_" is used for client-side feature flags
+    // Having env var either unset or "false" will disable the feature flag
+    const isEnabled =
+      (process.env[`FEATURE_${featureName}`] &&
+        process.env[`FEATURE_${featureName}`]?.toLowerCase() !== "false") ||
+      (process.env[`NEXT_PUBLIC_FEATURE_${featureName}`] &&
+        process.env[`NEXT_PUBLIC_FEATURE_${featureName}`]?.toLowerCase() !==
+          "false");
+
+    console.log("Using mock feature flag manager", {
+      featureName,
+      userId,
+      isEnabled,
+    });
+
+    return Promise.resolve(isEnabled);
   }
 }


### PR DESCRIPTION
## Ticket

Resolves #263

## Changes

- filled out functionality in `LocalFeatureFlagManager`
- uses env variables
- supports hot reload
- requires "FEATURE_" prefix for server-side feature flags
- requires "NEXT_PUBLIC_FEATURE_" prefix for client-side feature flags

## Context for reviewers

Ali had already implemented `FeatureFlagManager` for managing prod flags via AWS Evidently. This simply adds a fallback for testing locally where a connection to Evidently might not be possible.

