### PR TITLE
Disable noisy test coverage annotations

### DIFF
--- a/.github/workflows/ci-app.yml
+++ b/.github/workflows/ci-app.yml
@@ -38,10 +38,11 @@ jobs:
       - run: npm run test -- --testLocationInResults --json --outputFile=coverage/report.json
       - uses: ArtiomTr/jest-coverage-report-action@v2
         with:
-            coverage-file: coverage/report.json
-            test-script: npm test
-            working-directory: app
-            # base-coverage-file: report.json
+          coverage-file: coverage/report.json
+          test-script: npm test
+          working-directory: app
+          annotations: failed-tests
+          # base-coverage-file: report.json
 
   lint:
     name: Lint


### PR DESCRIPTION
## Changes

- Don't annotate lines of code that lack test coverage. It's too noisy, making a PR's file changes difficult to parse when reviewing a PR.

![CleanShot 2024-01-09 at 17 43 52@2x](https://github.com/navapbc/template-application-nextjs/assets/371943/642dc958-f2a1-43be-8bf2-e406522a3b5b)
