### PR TITLE
Fix AWS health check

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -101,4 +101,4 @@ ENV PORT 3000
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD HOSTNAME="0.0.0.0" node server.js


### PR DESCRIPTION
## Ticket

Resolves #305

## Changes

- Set `HOSTNAME` for the Docker container. This fixes an issue where the healthcheck fails after upgrading to Next.js 13.4.13+

## Context for reviewers

This was copied from the [Next.js Docker example](https://github.com/vercel/next.js/blob/3438b39fcfd64bec35cbc397d687744a7f3f66df/examples/with-docker/Dockerfile#L67C1-L67C38). I tried a [few](https://github.com/navapbc/platform-test-nextjs/commit/f1d0cb06ad95fe6ab8a2f2a27746b1c6a179b1b1) other [formats](https://github.com/navapbc/platform-test-nextjs/commit/fd933f911dbfd4e93c443d3fc0f31d76bb127aea), but none of those worked.

## Testing

Tested on the [Platform test app](https://github.com/navapbc/platform-test-nextjs)

![CleanShot 2024-04-26 at 10 03 31@2x](https://github.com/navapbc/template-application-nextjs/assets/371943/d51ca34e-4b0c-4263-946f-833e056a86a1)

