### PR TITLE
Exclude template.md from install/update

### DIFF
--- a/template-only-bin/install-template.sh
+++ b/template-only-bin/install-template.sh
@@ -25,3 +25,4 @@ echo "Remove files relevant only to template development"
 rm .github/workflows/template-only-*
 rm -rf .github/ISSUE_TEMPLATE
 rm -rf docs/decisions/template
+rm docs/decisions/template.md

--- a/template-only-bin/update-template.sh
+++ b/template-only-bin/update-template.sh
@@ -37,6 +37,7 @@ echo "Applying patch"
 # Note: Keep this list in sync with the removed files in install-template.sh
 EXCLUDE_OPT="--exclude=.github/workflows/template-only-* \
   --exclude=.github/ISSUE_TEMPLATE \
+  --exclude=docs/decisions/template.md \
   --exclude=docs/decisions/template"
 git apply $EXCLUDE_OPT --allow-empty template-application-nextjs/patch
 


### PR DESCRIPTION
This should fix an issue with the install/update script, since the infra template also installs/updates this file.

Tested the install script locally:

![CleanShot 2024-05-01 at 10 25 56@2x](https://github.com/navapbc/template-application-nextjs/assets/371943/66a091f2-aec1-4fb7-8fe1-f09f27408272)
