### PR TITLE
[Issue #236]: Server action example

### DIFF
--- a/app/src/app/[locale]/serverAction/page.tsx
+++ b/app/src/app/[locale]/serverAction/page.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { useFormState } from "react-dom";
+
+import {
+  Button,
+  Grid,
+  GridContainer,
+  Label,
+  TextInput,
+} from "@trussworks/react-uswds";
+
+import { updateServerData } from "../../serverActions/serverActionExample";
+
+const initialFormState = {
+  name: "",
+  email: "",
+};
+
+export default function SimpleForm() {
+  const [formData, updateFormData] = useFormState(
+    updateServerData,
+    initialFormState
+  );
+
+  const hasReturnedFormData = formData.name || formData.email;
+
+  return (
+    <GridContainer>
+      <Grid row>
+        <Grid col={12}>
+          <div className="usa-card">
+            <div className="usa-card__header">
+              <h2>Server Action Example</h2>
+            </div>
+            <div className="usa-card__body">
+              <form action={updateFormData}>
+                <Label htmlFor="name">Name</Label>
+                <TextInput
+                  id="name"
+                  name="name"
+                  type="text"
+                  defaultValue={formData.name}
+                />
+
+                <Label htmlFor="email">Email</Label>
+                <TextInput
+                  id="email"
+                  name="email"
+                  type="email"
+                  defaultValue={formData.email}
+                  className="margin-bottom-1"
+                />
+
+                <Button type="submit">Submit</Button>
+              </form>
+            </div>
+
+            {hasReturnedFormData && (
+              <>
+                <hr />
+                <div className="usa-card margin-top-2">
+                  <h4>Server Action returned data</h4>
+                  <div className="usa-card__body">
+                    {formData.name && (
+                      <div>
+                        <strong>Name:</strong> {formData.name}
+                      </div>
+                    )}
+                    {formData.email && (
+                      <div>
+                        <strong>Email:</strong> {formData.email}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </Grid>
+      </Grid>
+    </GridContainer>
+  );
+}

--- a/app/src/app/serverActions/serverActionExample.ts
+++ b/app/src/app/serverActions/serverActionExample.ts
@@ -1,0 +1,30 @@
+"use server";
+
+interface FormDataState {
+  name: string;
+  email: string;
+}
+
+export async function updateServerData(
+  prevState: FormDataState,
+  formData: FormData
+): Promise<FormDataState> {
+
+    
+  console.log("prevState => ", prevState);
+  console.log("formData => ", formData);
+
+  const name = formData.get("name") as string;
+  const email = formData.get("email") as string;
+
+  // In a real application, you would typically perform
+  // some server mutation.
+  await Promise.resolve();
+
+  const updatedData: FormDataState = {
+    name: name || prevState.name,
+    email: email || prevState.email,
+  };
+
+  return updatedData;
+}


### PR DESCRIPTION
## Ticket

Resolves #236 

## Changes

- add a server action example with `useFormState`

## Context for reviewers

- Chose the `useFormState` method (instead of just assigning the server action function to the `action` attribute of the form
    - I believe this can better handle form data and returned data - even server error messages / validation
    - I haven't played around with this but I believe you can better use optimistic updates when using `useFormState`
    
- the example uses native `form` instead of `USWDS` `<Form>` which require an `onSubmit`


- we found in the other project that you need to start using `refs` for deeply nested components that may need to submit the form
- For loading you might be able to tie in `useFormStatus` / `pending` state 

