### PR TITLE
[Issue #387]: Resolved Storybook build error

### DIFF
--- a/template/{{app_name}}/.storybook/main.js
+++ b/template/{{app_name}}/.storybook/main.js
@@ -5,7 +5,11 @@
  */
 // @ts-check
 
-import path from "path";
+import path, { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Support deploying to a subdirectory, such as GitHub Pages.
 const NEXT_PUBLIC_BASE_PATH = process.env.NEXT_PUBLIC_BASE_PATH ?? "";


### PR DESCRIPTION
## Ticket

Resolves #387 

## Changes

Updated the `.storybook/main.js` in the top-level app directory.

## Context for reviewers

The error occurs when running `npm run storybook` from the terminal to build a dev Storybook environment locally. I added the code below at the top of the file to explicitly set a __dirname value.

```
import path, { dirname } from "path";
import { fileURLToPath } from "url";

const __filename = fileURLToPath(import.meta.url);
const __dirname = dirname(__filename);
```

According to [Node.js documentation](https://nodejs.org/api/esm.html#differences-between-es-modules-and-commonjs), `__dirname` is unavailable in ES modules. They recommend [import.meta.dirname](https://nodejs.org/api/esm.html#importmetadirname) instead to replicate this behavior. 

I was able to find use cases for the recommended solution in this [Stack Overflow](https://stackoverflow.com/questions/8817423/why-is-dirname-not-defined-in-node-repl) thread as well as this [Medium blog article](https://iamwebwiz.medium.com/how-to-fix-dirname-is-not-defined-in-es-module-scope-34d94a86694d).

## Testing

Storybook builds and runs locally in `http://localhost:6006` as expected when the above command is used.
