### PR TITLE
[#387] Update Storybook nextConfigPath to support node modules

### DIFF
--- a/template/{{app_name}}/.storybook/main.mjs
+++ b/template/{{app_name}}/.storybook/main.mjs
@@ -26,7 +26,7 @@ const config = {
     // https://storybook.js.org/docs/get-started/nextjs
     name: "@storybook/nextjs",
     options: {
-      nextConfigPath: path.resolve(__dirname, "../next.config.js"),
+      nextConfigPath: path.resolve(import.meta.dirname, "../next.config.js"),
       builder: {
         // lazyCompilation breaks Storybook when running from within Docker
         // Google Translate this page for context: https://zenn.dev/yutaosawa/scraps/7764e5f17173d1

--- a/template/{{app_name}}/next-env.d.ts
+++ b/template/{{app_name}}/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Ticket

Resolves #387 

## Changes

<!-- What was added, updated, or removed in this PR. -->
- Updated .storybook/main.js => .storybook/main.mjs based on ECMAScript Modules instead of CommonJS
  - **.storybook/main.mjs:**
    ```    
    path.resolve(import.meta.dirname, "../next.config.js")
    ```

## Context for reviewers

<!-- Testing instructions, background context, more in-depth details of the implementation, and anything else you'd like to call out or ask reviewers. -->
Originally made an update to Storybook in #388 meant to address #387. Making these changes caused issues in [platform-test-nextjs](https://github.com/navapbc/platform-test-nextjs/actions/runs/13999633004/job/39317883628). 

The steps taken to resolve are in this [PR](https://github.com/navapbc/platform-test-nextjs/pull/98).

## Testing

<!-- Provide evidence that the code works as expected. Explain what was done for testing and the results of the test plan. Include screenshots, [GIF demos](https://getkap.co/), shell commands or output to help show the changes working as expected. ProTip: you can drag and drop or paste images into this textbox. -->
Making this change in platform-test-nextjs resulted in a successful app build (save for a vulnerability scan). This change also follows [Node.js documentation](https://nodejs.org/docs/latest/api/esm.html#no-__filename-or-__dirname) on what they recommend to use in place of `__dirname`.
