### PR TITLE
[chore] Update USWDS style import

### DIFF
--- a/template/{{app_name}}/src/styles/_uswds-core-optimized.scss
+++ b/template/{{app_name}}/src/styles/_uswds-core-optimized.scss
@@ -1,0 +1,87 @@
+// This file optimizes SCSS @forwards, as documented in this PR: https://github.com/uswds/uswds/pull/6566
+// Once this change is deployed, you can revert this change and use the default method of importing uswds core (@forward "uswds";)
+
+// Global
+@forward "uswds-elements/lib/normalize";
+@forward "uswds-core/src/styles";
+@forward "uswds-fonts/src/styles/font-face";
+@forward "uswds-elements/src/styles";
+@forward "uswds-helpers/src/styles";
+
+// Typography
+@forward "usa-content/src/styles/usa-content";
+@forward "usa-dark-background/src/styles/usa-dark-background";
+@forward "usa-display/src/styles/usa-display";
+@forward "usa-intro/src/styles/usa-intro";
+@forward "usa-link/src/styles/usa-link";
+@forward "usa-list/src/styles/usa-list";
+@forward "usa-paragraph/src/styles/usa-paragraph";
+@forward "usa-prose/src/styles/usa-prose";
+
+// Components
+@forward "usa-accordion/src/styles/usa-accordion";
+@forward "usa-alert/src/styles/usa-alert";
+@forward "usa-banner/src/styles/usa-banner";
+@forward "usa-breadcrumb/src/styles/usa-breadcrumb";
+@forward "usa-button-group/src/styles/usa-button-group";
+@forward "usa-button/src/styles/usa-button";
+@forward "usa-card/src/styles/usa-card";
+@forward "usa-checklist/src/styles/usa-checklist";
+@forward "usa-collection/src/styles/usa-collection";
+@forward "usa-embed-container/src/styles/usa-embed-container";
+@forward "usa-footer/src/styles/usa-footer";
+@forward "usa-form/src/styles/usa-form";
+@forward "usa-graphic-list/src/styles/usa-graphic-list";
+@forward "usa-header/src/styles/usa-header";
+@forward "usa-header/src/styles/usa-megamenu";
+@forward "usa-header/src/styles/usa-nav-container";
+@forward "usa-header/src/styles/usa-navbar";
+@forward "usa-hero/src/styles/usa-hero";
+@forward "usa-icon/src/styles/usa-icon";
+@forward "usa-icon-list/src/styles/usa-icon-list";
+@forward "usa-identifier/src/styles/usa-identifier";
+@forward "usa-in-page-navigation/src/styles/usa-in-page-navigation";
+@forward "usa-language-selector/src/styles/usa-language-selector";
+@forward "usa-layout-docs/src/styles/usa-layout-docs";
+@forward "usa-layout-grid/src/styles/usa-layout-grid";
+@forward "usa-media-block/src/styles/usa-media-block";
+@forward "usa-modal/src/styles/usa-modal";
+@forward "usa-nav/src/styles/usa-nav";
+@forward "usa-pagination/src/styles/usa-pagination";
+@forward "usa-process-list/src/styles/usa-process-list";
+@forward "usa-search/src/styles/usa-search";
+@forward "usa-section/src/styles/usa-section";
+@forward "usa-sidenav/src/styles/usa-sidenav";
+@forward "usa-site-alert/src/styles/usa-site-alert";
+@forward "usa-skipnav/src/styles/usa-skipnav";
+@forward "usa-step-indicator/src/styles/usa-step-indicator";
+@forward "usa-summary-box/src/styles/usa-summary-box";
+@forward "usa-table/src/styles/usa-table";
+@forward "usa-tag/src/styles/usa-tag";
+@forward "usa-tooltip/src/styles/usa-tooltip";
+
+// Form controls
+@forward "usa-input-list/src/styles/usa-input-list";
+@forward "usa-character-count/src/styles/usa-character-count";
+@forward "usa-checkbox/src/styles/usa-checkbox";
+@forward "usa-combo-box/src/styles/usa-combo-box";
+@forward "usa-date-picker/src/styles/usa-date-picker";
+@forward "usa-error-message/src/styles/usa-error-message";
+@forward "usa-fieldset/src/styles/usa-fieldset";
+@forward "usa-file-input/src/styles/usa-file-input";
+@forward "usa-form-group/src/styles/usa-form-group";
+@forward "usa-hint/src/styles/usa-hint";
+@forward "usa-input-prefix-suffix/src/styles/usa-input-prefix-suffix";
+@forward "usa-input/src/styles/usa-input";
+@forward "usa-input-mask/src/styles/usa-input-mask";
+@forward "usa-label/src/styles/usa-label";
+@forward "usa-legend/src/styles/usa-legend";
+@forward "usa-memorable-date/src/styles/usa-memorable-date";
+@forward "usa-radio/src/styles/usa-radio";
+@forward "usa-range/src/styles/usa-range";
+@forward "usa-select/src/styles/usa-select";
+@forward "usa-textarea/src/styles/usa-textarea";
+@forward "usa-time-picker/src/styles/usa-time-picker";
+
+// Utilities
+@forward "uswds-utilities/src/styles";

--- a/template/{{app_name}}/src/styles/styles.scss
+++ b/template/{{app_name}}/src/styles/styles.scss
@@ -1,3 +1,3 @@
 @forward "uswds-theme";
-@forward "uswds";
+@forward "uswds-core-optimized";
 @forward "uswds-theme-custom-styles";


### PR DESCRIPTION
## Ticket

n/a

## Changes

Manually imports (`@forward`) USWDS core SCSS components for faster compiling

## Context for reviewers

More info here: https://github.com/uswds/uswds/pull/6566

- **Note:** This change doesn't modify USWDS PostCSS behavior
- **Additional note:** This change alone doesn't speed up compilation as much as the linked USWDS PR suggests because this app isn't using `sass-embedded` for compilation. Related PR's to address this:
   - https://github.com/navapbc/template-application-nextjs/pull/442
   - https://github.com/navapbc/template-application-nextjs/pull/443

## Testing

- Both storybook and next.js build successfully
